### PR TITLE
Added Write Lifetime Hint support in classifier

### DIFF
--- a/modules/cas_cache/classifier.c
+++ b/modules/cas_cache/classifier.c
@@ -209,6 +209,17 @@ static cas_cls_eval_t _cas_cls_numeric_test_u(
 	return cas_cls_eval_no;
 }
 
+#ifdef WLTH_SUPPORT
+/* Write lifetime hint condition test */
+static cas_cls_eval_t _cas_cls_wlth_test(struct cas_classifier *cls,
+			      struct cas_cls_condition *c, struct cas_cls_io *io,
+			      ocf_part_id_t part_id)
+{
+	return _cas_cls_numeric_test_u(c, io->bio->bi_write_hint);
+}
+#endif
+
+
 /* Io class test function */
 static cas_cls_eval_t _cas_cls_io_class_test(struct cas_classifier *cls,
 		struct cas_cls_condition *c, struct cas_cls_io *io,
@@ -417,6 +428,10 @@ static struct cas_cls_condition_handler _handlers[] = {
 			_cas_cls_generic_dtr },
 	{ "directory", _cas_cls_directory_test, _cas_cls_directory_ctr,
 			_cas_cls_directory_dtr },
+#ifdef WLTH_SUPPORT
+	{ "wlth", _cas_cls_wlth_test, _cas_cls_numeric_ctr,
+			_cas_cls_generic_dtr},
+#endif
 	{ NULL }
 };
 

--- a/modules/cas_cache/linux_kernel_version.h
+++ b/modules/cas_cache/linux_kernel_version.h
@@ -83,6 +83,10 @@
 	#define BIO_OP_STATUS(bio) bio->bi_error
 #endif
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 13, 0)
+#define WLTH_SUPPORT
+#endif
+
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 3, 0)
 	#define BIO_ENDIO(BIO, BYTES_DONE, ERROR) \
 			({ BIO_OP_STATUS(BIO) = ERROR; bio_endio(BIO); })


### PR DESCRIPTION
Adding write lifetime hint support in classifier, available from kernel 4.13.

Signed-off-by: Michal Rakowski <michal.rakowski@intel.com>