### PR TITLE
Added possibility to disable cleaner thread.

### DIFF
--- a/modules/cas_cache/context.c
+++ b/modules/cas_cache/context.c
@@ -271,6 +271,11 @@ static int _cas_ctx_cleaner_init(ocf_cleaner_t c)
 	return cas_create_cleaner_thread(c);
 }
 
+static void _cas_ctx_cleaner_kick(ocf_cleaner_t c)
+{
+	return cas_kick_cleaner_thread(c);
+}
+
 static void _cas_ctx_cleaner_stop(ocf_cleaner_t c)
 {
 	return cas_stop_cleaner_thread(c);
@@ -364,6 +369,7 @@ static const struct ocf_ctx_config ctx_cfg = {
 
 		.cleaner = {
 			.init = _cas_ctx_cleaner_init,
+			.kick = _cas_ctx_cleaner_kick,
 			.stop = _cas_ctx_cleaner_stop,
 		},
 

--- a/modules/cas_cache/context.c
+++ b/modules/cas_cache/context.c
@@ -426,8 +426,6 @@ int cas_initialize_context(void)
 		goto err_block_dev;
 	}
 
-	ocf_mngt_core_pool_init(cas_ctx);
-
 	return 0;
 
 err_block_dev:
@@ -444,7 +442,6 @@ err_ctx:
 
 int cas_cleanup_context(void)
 {
-	ocf_mngt_core_pool_deinit(cas_ctx);
 	block_dev_deinit();
 	atomic_dev_deinit();
 	cas_garbage_collector_deinit();

--- a/modules/cas_cache/threads.h
+++ b/modules/cas_cache/threads.h
@@ -17,6 +17,7 @@ void cas_kick_queue_thread(ocf_queue_t q);
 void cas_stop_queue_thread(ocf_queue_t q);
 
 int cas_create_cleaner_thread(ocf_cleaner_t c);
+void cas_kick_cleaner_thread(ocf_cleaner_t c);
 void cas_stop_cleaner_thread(ocf_cleaner_t c);
 
 int cas_create_metadata_updater_thread(ocf_metadata_updater_t mu);


### PR DESCRIPTION
In case of cleaner thread retrived 'OCF_CLEANER_DISABLE' no cleaning is
performed until kick is called.

Signed-off-by: Michal Mielewczyk <michal.mielewczyk@intel.com>