### PR TITLE
Added more descriptive err msg for NVMe format

### DIFF
--- a/casadm/cas_main.c
+++ b/casadm/cas_main.c
@@ -1628,7 +1628,7 @@ static int handle_nvme_format()
 	}
 
 	if (!cas_capabilites.nvme_format) {
-		cas_printf(LOG_ERR, "Command is not supported\n");
+		cas_printf(LOG_ERR, "Command is not supported by current kernel\n");
 		return FAILURE;
 	}
 

--- a/casadm/extended_err_msg.c
+++ b/casadm/extended_err_msg.c
@@ -184,6 +184,10 @@ struct {
 		"NVMe is formatted to unsupported format"
 	},
 	{
+		KCAS_ERR_UNSUPPORTED_LBA_FORMAT,
+		"Specified LBA format is not supported by the NVMe device"
+	},
+	{
 		KCAS_ERR_CONTAINS_PART,
 		"Device contains partitions.\nIf you want to continue, "
 		"please use --force option.\nWarning: all data will be lost!"

--- a/modules/cas_cache/utils/utils_nvme.c
+++ b/modules/cas_cache/utils/utils_nvme.c
@@ -274,7 +274,7 @@ static int _cas_nvme_preformat_check(struct block_device *bdev, int force)
 	} else if (probe_ctx.error == -EBUSY) {
 		ret = -OCF_ERR_NOT_OPEN_EXC;
 	} else if (probe_ctx.error) {
-		/* Some error occurred, we do not have sure about clean cache */
+		/* Some error occurred, we are not sure whether cache is clean or not */
 		ret = -KCAS_ERR_FORMAT_FAILED;
 	} else {
 		/* Check if cache was closed in proper way */
@@ -352,7 +352,7 @@ static int _cas_nvme_format_namespace_by_path(const char *device_path,
 	}
 
 	if (best_lbaf < 0) {
-		ret = -KCAS_ERR_FORMAT_FAILED;
+		ret = -KCAS_ERR_UNSUPPORTED_LBA_FORMAT;
 		goto out2;
 	}
 
@@ -509,7 +509,7 @@ static int _cas_nvme_format_character_device(const char *device_path,
 	}
 
 	if (best_lbaf < 0) {
-		ret = -KCAS_ERR_FORMAT_FAILED;
+		ret = -KCAS_ERR_UNSUPPORTED_LBA_FORMAT;
 		goto cleanup;
 	}
 

--- a/modules/include/cas_ioctl_codes.h
+++ b/modules/include/cas_ioctl_codes.h
@@ -544,6 +544,9 @@ enum kcas_error {
 	/** NVMe is formatted to unsupported format */
 	KCAS_ERR_NVME_BAD_FORMAT,
 
+	/** Specified LBA format is not supported by the NVMe device */
+	KCAS_ERR_UNSUPPORTED_LBA_FORMAT,
+
 	/** Device contains partitions */
 	KCAS_ERR_CONTAINS_PART,
 


### PR DESCRIPTION
Changed error msg to more descriptive in case of NVMe format not supported by kernel or unsupported LBA format.

Signed-off-by: Michal Rakowski <michal.rakowski@intel.com>