### PR TITLE
Basic WLTH-ioclass tests added

### DIFF
--- a/test/smoke_test/cas_functions
+++ b/test/smoke_test/cas_functions
@@ -879,6 +879,49 @@ stats() {
     clear_options
 }
 
+check_fio_ver() {
+    check_options ${FUNCNAME[0]}
+
+    fio_ver="$(fio -v)"
+    if [ -z $fio_ver ] ; then
+	echo_yellow "Fio is not installed, skipping test!"
+	return 1
+    fi
+
+    major=`echo $fio_ver | cut -d '.' -f 1 | cut -d '-' -f 2`
+    minor=`echo $fio_ver | cut -d '.' -f 2`
+    if [[ $major -lt $FIO_MAJOR_OPTION ]] ; then
+	echo_yellow "Invalid fio version, skipping test!"
+	return 1
+    elif [[ $major -eq $FIO_MAJOR_OPTION ]] && \
+	    [[ $minor -lt $FIO_MINOR_OPTION ]] ; then
+	echo_yellow "Invalid fio minor revision, skipping test!"
+	return 1
+    fi
+
+    clear_options
+    return 0
+}
+
+check_kernel_ver() {
+    check_options ${FUNCNAME[0]}
+
+    kernel_ver="$(uname -r)"
+    kernel_version=`echo ${kernel_ver} | cut  -d '.' -f 1`
+    major=`echo ${kernel_ver} | cut  -d '.' -f 2`
+    if [[ $kernel_version -lt $KERNEL_VER_OPTION ]] ; then
+	echo_yellow "Invalid kernel version, skipping test!"
+	return 1
+    elif [[ $kernel_version -eq $KERNEL_VER_OPTION ]] && \
+		[[ $major -lt $KERNEL_MAJOR_OPTION ]] ; then
+	echo_yellow "Invalid kernel major revision, skipping test!"
+	return 1
+    fi
+
+    clear_options
+    return 0
+}
+
 export -f mount_cache
 export -f remove_partitions
 export -f make_primary_partitions
@@ -893,6 +936,8 @@ export -f io_class_load
 export -f stats
 export -f io_class_stats
 export -f check_is_nvme_atomic
+export -f check_fio_ver
+export -f check_kernel_ver
 
 export CAS_FUNCTIONS_LOADED="1"
 

--- a/test/smoke_test/cas_options
+++ b/test/smoke_test/cas_options
@@ -24,6 +24,8 @@ export ALL_OPTIONS="
     STAT_UNIT_OPTION STAT_NAME_OPTION
     STORE_CONFIG_OPTION
     CLEAN_POL_OPTION
+    KERNEL_VER_OPTION KERNEL_MAJOR_OPTION
+    FIO_MAJOR_OPTION FIO_MINOR_OPTION
 "
 
 # Specify ONLY required options here. The name of the variable should start with
@@ -72,6 +74,9 @@ export IO_CLASS_EXT_REMOVE_REQUIRED_OPTIONS="CACHE_ID_OPTION IO_CLASS_ID"
 
 export STATS_REQUIRED_OPTIONS="CACHE_ID_OPTION"
 export GET_STATS_VALUE_REQUIRED_OPTIONS="CACHE_ID_OPTION STAT_NAME_OPTION"
+
+export CHECK_KERNEL_VER_REQUIRED_OPTIONS="KERNEL_VER_OPTION KERNEL_MAJOR_OPTION"
+export CHECK_FIO_VER_REQUIRED_OPTIONS="FIO_MAJOR_OPTION FIO_MINOR_OPTION"
 
 # Clearing the variables below is not really needed, but it makes the whole
 # thing much more clear. Unlike the REQUIRED_OPTIONS, we specify all
@@ -297,6 +302,18 @@ ACTIVITY_THRESH_OPTION=""
 ############################################################
 DEVICE_ID_OPTION=""
 CLEAN_POLICY_NS_OPTION=""
+
+############################################################
+#                  CHECK KERNEL VER                        #
+############################################################
+KERNEL_VER_OPTION=""
+KERNEL_MAJOR_OPTION=""
+
+############################################################
+#                  CHECK FIO VER                        #
+############################################################
+FIO_MAJOR_OPTION=""
+FIO_MINOR_OPTION=""
 
 ############################################################
 #                        FUNCTIONS                         #

--- a/test/smoke_test/io_class/01_wlth
+++ b/test/smoke_test/io_class/01_wlth
@@ -1,0 +1,67 @@
+#!/bin/bash
+#
+# Copyright(c) 2012-2019 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+#
+
+# The line below specified that line under it should be used as the test's short description when launching test via run_tests script.
+# The text should not be longer than 80 chars - if it is, the script will strip addititonal characters
+# DESCRIPTION IO Class - setting and listing check with WLTH set
+
+# Standard beginning for every test - get the main tests directory and
+# link the cas_lib file for CAS API, then use "start_test $*" to pass params
+# and do other necessary checks and setup.
+
+# The line below says that this test should be included in BVT - it will be launched, when we use "./run_tests -b"
+# USE_IN_BVT
+# USE_IN_NIGHTLY
+
+TESTS_DIR="$(dirname $0)/../"
+. $TESTS_DIR/cas_lib
+. $TESTS_DIR/io_class/cas_lib_io_class
+
+start_test $*
+
+# Check if current kernel supports write hints
+KERNEL_VER_OPTION="4" KERNEL_MAJOR_OPTION="13" check_kernel_ver
+if [ "$?" -ne 0 ] ; then
+	end_test $CAS_TEST_NOT_RUN
+fi
+
+# Check if fio supports write hints
+FIO_MAJOR_OPTION="3" FIO_MINOR_OPTION="13" check_fio_ver
+if [ "$?" -ne 0 ] ; then
+	end_test $CAS_TEST_NOT_RUN
+fi
+
+test_log_start
+
+# Use CACHE_DEVICE and CORE_DEVICE provided by configuration file and remove partitions from those devices
+TARGET_DEVICE_OPTION="$CACHE_DEVICE" remove_partitions
+TARGET_DEVICE_OPTION="$CORE_DEVICE" remove_partitions
+
+# Create 200M primary partition on CACHE_DEVICE
+TARGET_DEVICE_OPTION="$CACHE_DEVICE" PARTITION_SIZE_OPTION="200M" PARTITION_IDS_OPTION="1" make_primary_partitions
+# Create 400M primary partition on CORE_DEVICE
+TARGET_DEVICE_OPTION="$CORE_DEVICE" PARTITION_SIZE_OPTION="400M" PARTITION_IDS_OPTION="1" make_primary_partitions
+
+# Start cache
+CACHE_ID_OPTION="1" CACHE_DEVICE_OPTION="${CACHE_DEVICE}1" start_cache
+
+# Add core
+CACHE_ID_OPTION="1" CORE_DEVICE_OPTION="${CORE_DEVICE}1" add_core
+
+# Prepare IO class config with wlth specified
+io_class_config_wlth
+
+# Load config
+CACHE_ID_OPTION="1" CSV_FILE=$(io_class_config_file) io_class_load
+
+# Compare cache IO class config with generated one
+CACHE_ID_OPTION="1" CSV_FILE=$(io_class_config_file) io_class_cmp
+
+# Stop cache
+CACHE_ID_OPTION="1" stop_cache
+
+test_log_stop
+end_test 0

--- a/test/smoke_test/io_class/02_wlth
+++ b/test/smoke_test/io_class/02_wlth
@@ -1,0 +1,126 @@
+#!/bin/bash
+#
+# Copyright(c) 2012-2019 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+#
+
+# The line below specified that line under it should be used as the test's short description when launching test via run_tests script.
+# The text should not be longer than 80 chars - if it is, the script will strip addititonal characters
+# DESCRIPTION IO Class - verification of correct classificiation of wlth-marked io
+
+# Standard beginning for every test - get the main tests directory and
+# link the cas_lib file for CAS API, then use "start_test $*" to pass params
+# and do other necessary checks and setup.
+
+# The line below says that this test should be included in BVT - it will be launched, when we use "./run_tests -b"
+# USE_IN_BVT
+# USE_IN_NIGHTLY
+
+TESTS_DIR="$(dirname $0)/../"
+. $TESTS_DIR/cas_lib
+. $TESTS_DIR/io_class/cas_lib_io_class
+
+L_TEST_STATUS=0
+
+start_test $*
+
+# Check if current kernel supports write hints
+KERNEL_VER_OPTION="4" KERNEL_MAJOR_OPTION="13" check_kernel_ver
+if [ "$?" -ne 0 ] ; then
+	end_test $CAS_TEST_NOT_RUN
+fi
+
+# Check if fio supports write hints
+FIO_MAJOR_OPTION="3" FIO_MINOR_OPTION="13" check_fio_ver
+if [ "$?" -ne 0 ] ; then
+	end_test $CAS_TEST_NOT_RUN
+fi
+
+test_log_start
+
+# Use CACHE_DEVICE and CORE_DEVICE provided by configuration file and remove partitions from those devices
+TARGET_DEVICE_OPTION="$CACHE_DEVICE" remove_partitions
+TARGET_DEVICE_OPTION="$CORE_DEVICE" remove_partitions
+
+# Create 200M primary partition on CACHE_DEVICE
+TARGET_DEVICE_OPTION="$CACHE_DEVICE" PARTITION_SIZE_OPTION="200M" PARTITION_IDS_OPTION="1" make_primary_partitions
+# Create 400M primary partition on CORE_DEVICE
+TARGET_DEVICE_OPTION="$CORE_DEVICE" PARTITION_SIZE_OPTION="400M" PARTITION_IDS_OPTION="1" make_primary_partitions
+
+# Start cache
+CACHE_ID_OPTION="1" CACHE_DEVICE_OPTION="${CACHE_DEVICE}1" start_cache
+
+# Add core
+CACHE_ID_OPTION="1" CORE_DEVICE_OPTION="${CORE_DEVICE}1" add_core
+
+# Prepare IO class config with wlth specified
+io_class_config_wlth
+
+# Load config
+CACHE_ID_OPTION="1" CSV_FILE=$(io_class_config_file) io_class_load
+
+# Run fio with all possible write hints specified (each of them has different
+# io size)
+run_cmd fio --filename=/dev/cas1-1 --rw=write --direct=1 \
+--name=wh_none --size=4096 --ioengine=libaio --write_hint=none --iodepth=1 --numjobs=1 \
+--name=wh_short --size=8192 --ioengine=libaio --write_hint=short --iodepth=1 --numjobs=1 \
+--name=wh_medium --size=12288 --ioengine=libaio --write_hint=medium --iodepth=1 --numjobs=1 \
+--name=wh_long --size=16384 --ioengine=libaio --write_hint=long --iodepth=1 --numjobs=1 \
+--name=wh_extreme --size=20480 --ioengine=libaio --write_hint=extreme --iodepth=1 --numjobs=1
+
+echo "Verification if io was correctly WLTH-marked and classified..."
+
+# Verify if each if the wlth io class has expected written blocks count
+CACHE_ID_OPTION="1" STAT_NAME_OPTION="Blocks writes" IO_CLASS_ID="0" get_stats_value
+if [ $OUTPUT -ne 0 ] ; then
+	error "Incorrect block writes count (IO Class id 0)!"
+	L_TEST_STATUS=1
+fi
+
+# WLTH_NOT_SET
+CACHE_ID_OPTION="1" STAT_NAME_OPTION="Blocks writes" IO_CLASS_ID="1" get_stats_value
+if [ $OUTPUT -ne 0 ] ; then
+	error "Incorrect block writes count (IO Class id 1)!"
+	L_TEST_STATUS=1
+fi
+
+# WLTH_NONE
+CACHE_ID_OPTION="1" STAT_NAME_OPTION="Blocks writes" IO_CLASS_ID="2" get_stats_value
+if [ $OUTPUT -ne 1 ] ; then
+	error "Incorrect block writes count (IO Class id 2)!"
+	L_TEST_STATUS=1
+fi
+
+# WLTH_SHORT
+CACHE_ID_OPTION="1" STAT_NAME_OPTION="Blocks writes" IO_CLASS_ID="3" get_stats_value
+if [ $OUTPUT -ne 2 ] ; then
+	error "Incorrect block writes count (IO Class id 3)!"
+	L_TEST_STATUS=1
+fi
+
+# WLTH_MEDIUM
+CACHE_ID_OPTION="1" STAT_NAME_OPTION="Blocks writes" IO_CLASS_ID="4" get_stats_value
+if [ $OUTPUT -ne 3 ] ; then
+	error "Incorrect block writes count (IO Class id 4)!"
+	L_TEST_STATUS=1
+fi
+
+# WLTH_LONG
+CACHE_ID_OPTION="1" STAT_NAME_OPTION="Blocks writes" IO_CLASS_ID="5" get_stats_value
+if [ $OUTPUT -ne 4 ] ; then
+	error "Incorrect block writes count (IO Class id 5)!"
+	L_TEST_STATUS=1
+fi
+
+# WLTH_EXTREME
+CACHE_ID_OPTION="1" STAT_NAME_OPTION="Blocks writes" IO_CLASS_ID="6" get_stats_value
+if [ $OUTPUT -ne 5 ] ; then
+	error "Incorrect block writes count (IO Class id 6)!"
+	L_TEST_STATUS=1
+fi
+
+# Stop cache
+CACHE_ID_OPTION="1" stop_cache
+
+test_log_stop
+end_test $L_TEST_STATUS

--- a/test/smoke_test/io_class/cas_lib_io_class
+++ b/test/smoke_test/io_class/cas_lib_io_class
@@ -1,0 +1,134 @@
+#!/bin/bash
+#
+# Copyright(c) 2012-2019 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+#
+
+OCF_IO_CLASS_CONFIG_PATH="config.csv"
+
+#
+# Get path of config file
+#
+io_class_config_file () {
+    echo "${TESTS_DIR}/io_class/${OCF_IO_CLASS_CONFIG_PATH}"
+}
+
+#
+# Initialze config file for io class configuration
+#
+io_class_config_init () {
+    local L_CONFIG=$(io_class_config_file)
+
+    echo "IO class id,IO class name,Eviction priority,Allocation" > $L_CONFIG
+}
+
+#
+# Add specified IO class configuration
+#
+#param1 - IO class id
+#param2 - IO class name
+#param3 - IO class priority
+#param4 - IO class allocation
+io_class_config_add () {
+    local L_CONFIG=$(io_class_config_file)
+    local L_ID=$1
+    local L_NAME=$2
+    local L_PRIO=$3
+    local L_ALLOC=$4
+
+    echo "${L_ID},${L_NAME},${L_PRIO},${L_ALLOC}" >> $L_CONFIG
+}
+
+#
+# Create none IO Class configuration. This kind of configuration is present
+# at the CAS cache startup
+#
+io_class_config_none () {
+    io_class_config_init
+    io_class_config_add 0 "unclassified" 255 1
+}
+
+#
+# Create IO Class configuration with WLTH
+#
+io_class_config_wlth () {
+    io_class_config_init
+    io_class_config_add 0 "unclassified" 255 1
+    io_class_config_add 1 "wlth:eq:0" 6 1
+    io_class_config_add 2 "wlth:eq:1" 5 1
+    io_class_config_add 3 "wlth:eq:2" 4 1
+    io_class_config_add 4 "wlth:eq:3" 3 1
+    io_class_config_add 5 "wlth:eq:4" 2 1
+    io_class_config_add 6 "wlth:eq:5" 1 1
+}
+
+#
+# Compare CAS cache IO configuration class with configuration from a file
+#
+# Parameters:
+# CACHE_ID_OPTION - Cache ID
+# CONFIG_FILE - Input file with configuration to be compared
+#
+# return status:
+# 0 - the cache IO class configuration and file configuration is the same
+# 1 - the configuration is different
+io_class_cmp () {
+    local L_CSV_FILE=${CSV_FILE}
+    local L_IO_CLASS_CONFIG_CACHE=""
+
+    if [[ "" == ${CACHE_ID_OPTION} ]]
+    then
+        test_log_trace "Cache ID option is missing"
+        return 1
+    fi
+
+    if [ "" == "${L_CSV_FILE}" ]
+    then
+        test_log_trace "Configuration file to be compared is missing"
+        return 1
+    fi
+    local CACHE_ID_TMP=$CACHE_ID_OPTION
+
+    OUT_FILE="out.csv"
+    CSV_FILE=$OUT_FILE io_class_list
+    unset CSV_FILE
+    CACHE_ID_OPTION=$CACHE_ID_TMP io_class_list
+    L_IO_CLASS_CONFIG_CACHE=${RUN_CMD_OUTPUT} # Collect output result
+
+    #
+    # Remove CLI output decoration
+    #
+    L_IO_CLASS_CONFIG_CACHE=$(echo "${L_IO_CLASS_CONFIG_CACHE}" | grep -v '==')
+    L_IO_CLASS_CONFIG_CACHE=$(echo "${L_IO_CLASS_CONFIG_CACHE}" | sed '1!s/[\+\|\-]//g')
+    L_IO_CLASS_CONFIG_CACHE=$(echo "${L_IO_CLASS_CONFIG_CACHE}" | tr -s ' ')
+    L_IO_CLASS_CONFIG_CACHE=$(echo "${L_IO_CLASS_CONFIG_CACHE}" | sed 's/^\ //')
+    L_IO_CLASS_CONFIG_CACHE=$(echo "${L_IO_CLASS_CONFIG_CACHE}" | sed 's/\ $//')
+    L_IO_CLASS_CONFIG_CACHE=$(echo "${L_IO_CLASS_CONFIG_CACHE}" | grep -v '^$')
+    L_IO_CLASS_CONFIG_CACHE=$(echo "${L_IO_CLASS_CONFIG_CACHE}" | sed '1s/ | /,/g')
+    L_IO_CLASS_CONFIG_CACHE=$(echo "${L_IO_CLASS_CONFIG_CACHE}" | sed '1s/^| //')
+    L_IO_CLASS_CONFIG_CACHE=$(echo "${L_IO_CLASS_CONFIG_CACHE}" | sed '1s/ |$//')
+    L_IO_CLASS_CONFIG_CACHE=$(echo "${L_IO_CLASS_CONFIG_CACHE}" | sed '1!s/\ /,/g')
+    L_IO_CLASS_CONFIG_CACHE=$(echo "${L_IO_CLASS_CONFIG_CACHE}" | sed 's/YES/1/g')
+    L_IO_CLASS_CONFIG_CACHE=$(echo "${L_IO_CLASS_CONFIG_CACHE}" | sed 's/NO/0/g')
+    L_IO_CLASS_CONFIG_CACHE=$(echo "${L_IO_CLASS_CONFIG_CACHE}" | sed 's/Pinned//g')
+
+    #
+    # Compare output file with input file
+    #
+    diff $OUT_FILE $L_CSV_FILE
+    if [ $? -ne 0 ]
+    then
+        test_log_trace "Exported IO class configuration file mismatch"
+        return 1
+    fi
+
+    echo "${L_IO_CLASS_CONFIG_CACHE}" > ${OUT_FILE}
+    diff $OUT_FILE $L_CSV_FILE
+    if [ $? -ne 0 ]
+    then
+        test_log_trace "CLI IO class configuration file mismatch"
+        return 1
+    fi
+
+    return 0
+}

--- a/test/smoke_test/run_tests
+++ b/test/smoke_test/run_tests
@@ -318,7 +318,7 @@ sum_up_and_exit() {
 
     echo "More details in $LOGS_FOLDER"
     export_results_to_html
-    if [ $PASSED == $TESTS ] ; then
+    if [ $(($PASSED + $NOT_RUN)) == $TESTS ] ; then
         exit 0
     else
         exit 1


### PR DESCRIPTION
Adding basic tests for WLTH IO classification.
Since it is dependent on specific kernel version these tests are not currently included in BVT scope.

Signed-off-by: Michal Rakowski <michal.rakowski@intel.com>