### PR TITLE
Translate OCF-error-codes in IO path

### DIFF
--- a/casadm/extended_err_msg.c
+++ b/casadm/extended_err_msg.c
@@ -73,6 +73,9 @@ struct {
 		OCF_ERR_IO_CLASS_NOT_EXIST,
 		"No such IO class ID in the cache"
 	},
+	{	OCF_ERR_IO,
+		"I/O error"
+	},
 	{
 		OCF_ERR_WRITE_CACHE,
 		"Error while writing to cache device"
@@ -112,6 +115,22 @@ struct {
 	{
 		OCF_ERR_NOT_OPEN_EXC,
 		"Cannot open device exclusively"
+	},
+	{
+		OCF_ERR_AGAIN,
+		"Try again"
+	},
+	{
+		OCF_ERR_NOT_SUPP,
+		"Operation not supported"
+	},
+	{
+		OCF_ERR_METADATA_VER,
+		"Metadata version mismatch"
+	},
+	{
+		OCF_ERR_NO_METADATA,
+		"No metadata found on device"
 	},
 
 	/* CAS kernel error mappings*/

--- a/modules/cas_cache/service_ui_ioctl.c
+++ b/modules/cas_cache/service_ui_ioctl.c
@@ -4,76 +4,7 @@
 */
 
 #include "cas_cache.h"
-
-struct {
-	int cas_error;
-	int std_error;
-} static cas_error_code_map[] = {
-	/* IOC error mappings*/
-	{ OCF_ERR_INVAL,			EINVAL	},
-	{ OCF_ERR_INVAL_VOLUME_TYPE,		EINVAL	},
-	{ OCF_ERR_INTR,				EINTR	},
-	{ OCF_ERR_UNKNOWN,			EINVAL	},
-	{ OCF_ERR_TOO_MANY_CACHES,		ENOSPC	},
-	{ OCF_ERR_NO_MEM,			ENOMEM	},
-	{ OCF_ERR_NO_FREE_RAM,			ENOMEM	},
-	{ OCF_ERR_START_CACHE_FAIL,		EFAULT	},
-	{ OCF_ERR_CACHE_NOT_EXIST,		ENODEV	},
-	{ OCF_ERR_CACHE_EXIST,			EEXIST	},
-	{ OCF_ERR_TOO_MANY_CORES,		ENOSPC	},
-	{ OCF_ERR_CORE_NOT_AVAIL,		ENAVAIL	},
-	{ OCF_ERR_NOT_OPEN_EXC,			EBUSY	},
-	{ OCF_ERR_CACHE_NOT_AVAIL,		ENAVAIL	},
-	{ OCF_ERR_IO_CLASS_NOT_EXIST,		ENODEV	},
-	{ OCF_ERR_WRITE_CACHE,			EIO	},
-	{ OCF_ERR_WRITE_CORE,			EIO	},
-	{ OCF_ERR_DIRTY_SHUTDOWN,		EFAULT	},
-	{ OCF_ERR_DIRTY_EXISTS,			EFAULT	},
-	{ OCF_ERR_FLUSHING_INTERRUPTED,		EINTR	},
-
-	/* CAS kernel error mappings*/
-	{ KCAS_ERR_ROOT,			EPERM	},
-	{ KCAS_ERR_SYSTEM,			EINVAL	},
-	{ KCAS_ERR_BAD_RANGE,			ERANGE	},
-	{ KCAS_ERR_DEV_SPACE,			ENOSPC	},
-	{ KCAS_ERR_INV_IOCTL,			EINVAL	},
-	{ KCAS_ERR_DEV_PENDING,			EBUSY	},
-	{ KCAS_ERR_DIRTY_EXISTS_NVME,		EFAULT	},
-	{ KCAS_ERR_FILE_EXISTS,			EEXIST	},
-	{ KCAS_ERR_IN_UPGRADE,			EFAULT	},
-	{ KCAS_ERR_UNALIGNED,			EINVAL	},
-	{ KCAS_ERR_NO_STORED_CONF,		EINTR	},
-	{ KCAS_ERR_ROLLBACK,			EFAULT	},
-	{ KCAS_ERR_NOT_NVME,			ENODEV	},
-	{ KCAS_ERR_FORMAT_FAILED,		EFAULT	},
-	{ KCAS_ERR_NVME_BAD_FORMAT,		EINVAL	},
-	{ KCAS_ERR_CONTAINS_PART,		EINVAL	},
-	{ KCAS_ERR_A_PART,			EINVAL	},
-	{ KCAS_ERR_REMOVED_DIRTY,		EIO	},
-	{ KCAS_ERR_STOPPED_DIRTY,		EIO	},
-};
-
-/*******************************************/
-/* Helper which change cas-specific error  */
-/* codes to kernel generic error codes     */
-/*******************************************/
-
-int map_cas_err_to_generic_code(int cas_error_code)
-{
-	int i;
-
-	if (cas_error_code == 0)
-		return 0; /* No Error */
-
-	cas_error_code = abs(cas_error_code);
-
-	for (i = 0; i < ARRAY_SIZE(cas_error_code_map); i++) {
-		if (cas_error_code_map[i].cas_error == cas_error_code)
-			return -cas_error_code_map[i].std_error;
-	}
-
-	return -cas_error_code;
-}
+#include "utils/cas_err.h"
 
 #define _GET_CMD_INFO(cmd_info, arg, size) ({ \
 	cmd_info = vmalloc(size); \
@@ -97,7 +28,7 @@ int map_cas_err_to_generic_code(int cas_error_code)
 		ret = -EFAULT; \
 	} \
 	vfree(cmd_info); \
-	return map_cas_err_to_generic_code(ret); \
+	return map_cas_err_to_generic(ret); \
 })
 
 /* this handles IOctl for /dev/cas */

--- a/modules/cas_cache/utils/cas_err.h
+++ b/modules/cas_cache/utils/cas_err.h
@@ -1,0 +1,81 @@
+/*
+* Copyright(c) 2012-2019 Intel Corporation
+* SPDX-License-Identifier: BSD-3-Clause-Clear
+*/
+
+#include "cas_cache.h"
+
+
+struct {
+	int cas_error;
+	int std_error;
+} static cas_error_code_map[] = {
+	/* OCF error mappings*/
+	{ OCF_ERR_INVAL,			EINVAL	},
+	{ OCF_ERR_INVAL_VOLUME_TYPE,		EINVAL	},
+	{ OCF_ERR_INTR,				EINTR	},
+	{ OCF_ERR_UNKNOWN,			EINVAL	},
+	{ OCF_ERR_TOO_MANY_CACHES,		ENOSPC	},
+	{ OCF_ERR_NO_MEM,			ENOMEM	},
+	{ OCF_ERR_NO_FREE_RAM,			ENOMEM	},
+	{ OCF_ERR_START_CACHE_FAIL,		EFAULT	},
+	{ OCF_ERR_CACHE_NOT_EXIST,		ENODEV	},
+	{ OCF_ERR_CACHE_EXIST,			EEXIST	},
+	{ OCF_ERR_TOO_MANY_CORES,		ENOSPC	},
+	{ OCF_ERR_CORE_NOT_AVAIL,		ENAVAIL	},
+	{ OCF_ERR_NOT_OPEN_EXC,			EBUSY	},
+	{ OCF_ERR_CACHE_NOT_AVAIL,		ENAVAIL	},
+	{ OCF_ERR_IO_CLASS_NOT_EXIST,		ENODEV	},
+	{ OCF_ERR_IO,				EIO	},
+	{ OCF_ERR_WRITE_CACHE,			EIO	},
+	{ OCF_ERR_WRITE_CORE,			EIO	},
+	{ OCF_ERR_DIRTY_SHUTDOWN,		EFAULT	},
+	{ OCF_ERR_DIRTY_EXISTS,			EFAULT	},
+	{ OCF_ERR_FLUSHING_INTERRUPTED,		EINTR	},
+	{ OCF_ERR_AGAIN,			EAGAIN  },
+	{ OCF_ERR_NOT_SUPP,			ENOTSUP },
+	{ OCF_ERR_METADATA_VER,			EBADF	},
+	{ OCF_ERR_NO_METADATA,			ENODATA	},
+
+	/* CAS kernel error mappings*/
+	{ KCAS_ERR_ROOT,			EPERM	},
+	{ KCAS_ERR_SYSTEM,			EINVAL	},
+	{ KCAS_ERR_BAD_RANGE,			ERANGE	},
+	{ KCAS_ERR_DEV_SPACE,			ENOSPC	},
+	{ KCAS_ERR_INV_IOCTL,			EINVAL	},
+	{ KCAS_ERR_DEV_PENDING,			EBUSY	},
+	{ KCAS_ERR_DIRTY_EXISTS_NVME,		EFAULT	},
+	{ KCAS_ERR_FILE_EXISTS,			EEXIST	},
+	{ KCAS_ERR_IN_UPGRADE,			EFAULT	},
+	{ KCAS_ERR_UNALIGNED,			EINVAL	},
+	{ KCAS_ERR_NO_STORED_CONF,		EINTR	},
+	{ KCAS_ERR_ROLLBACK,			EFAULT	},
+	{ KCAS_ERR_NOT_NVME,			ENODEV	},
+	{ KCAS_ERR_FORMAT_FAILED,		EFAULT	},
+	{ KCAS_ERR_NVME_BAD_FORMAT,		EINVAL	},
+	{ KCAS_ERR_CONTAINS_PART,		EINVAL	},
+	{ KCAS_ERR_A_PART,			EINVAL	},
+	{ KCAS_ERR_REMOVED_DIRTY,		EIO	},
+	{ KCAS_ERR_STOPPED_DIRTY,		EIO	},
+};
+
+/*******************************************/
+/* Helper which change cas-specific error  */
+/* codes to kernel generic error codes     */
+/*******************************************/
+static inline int map_cas_err_to_generic(int cas_error_code)
+{
+	int i;
+
+	if (cas_error_code == 0)
+		return 0; /* No Error */
+
+	cas_error_code = abs(cas_error_code);
+
+	for (i = 0; i < ARRAY_SIZE(cas_error_code_map); i++) {
+		if (cas_error_code_map[i].cas_error == cas_error_code)
+			return -cas_error_code_map[i].std_error;
+	}
+
+	return -cas_error_code;
+}

--- a/modules/cas_cache/volume/vol_block_dev_top.c
+++ b/modules/cas_cache/volume/vol_block_dev_top.c
@@ -4,6 +4,7 @@
 */
 
 #include "cas_cache.h"
+#include "utils/cas_err.h"
 
 #define BLK_RQ_POS(rq) (CAS_BIO_BISECTOR((rq)->bio))
 #define BLK_RQ_BYTES(rq) blk_rq_bytes(rq)
@@ -12,12 +13,12 @@ extern u32 use_io_scheduler;
 
 static inline void __blockdev_end_request_all(struct request *rq, int error)
 {
-	 __blk_end_request_all(rq, error);
+	__blk_end_request_all(rq, map_cas_err_to_generic(error));
 }
 
 static inline void _blockdev_end_request_all(struct request *rq, int error)
 {
-	 blk_end_request_all(rq, error);
+	blk_end_request_all(rq, map_cas_err_to_generic(error));
 }
 
 static inline bool _blockdev_can_handle_rq(struct request *rq)


### PR DESCRIPTION
Translate error codes from OCF-specific to Linux ones.

Signed-off-by: Michal Rakowski <michal.rakowski@intel.com>