### PR TITLE
Fix old metadata detection.

### DIFF
--- a/modules/cas_cache/layer_cache_management.c
+++ b/modules/cas_cache/layer_cache_management.c
@@ -384,7 +384,7 @@ static void cache_mngt_metadata_probe_end(void *priv, int error,
 
 	*context->result = error;
 
-	if (error == -ENODATA || error == -EBADF) {
+	if (error == -OCF_ERR_NO_METADATA || error == -OCF_ERR_METADATA_VER) {
 		cmd_info->is_cache_device = false;
 		*context->result = 0;
 	} else if (error == 0) {


### PR DESCRIPTION
Due the changes in ocf error codes adapter misinterpreted information about no
preexisting metadata.

Signed-off-by: Michal Mielewczyk <michal.mielewczyk@intel.com>