### PR TITLE
Respect KERNEL_DIR environment variable

### DIFF
--- a/configure.d/Makefile
+++ b/configure.d/Makefile
@@ -9,6 +9,6 @@ obj-m += test_mod.o
 MAKE_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
 all:
-	make -C /lib/modules/$(shell uname -r)/build M=$(MAKE_DIR) modules
+	make -C $(KERNEL_DIR) M=$(MAKE_DIR) modules
 clean:
-	make -C /lib/modules/$(shell uname -r)/build M=$(MAKE_DIR) clean
+	make -C $(KERNEL_DIR) M=$(MAKE_DIR) clean

--- a/configure.d/conf_framework
+++ b/configure.d/conf_framework
@@ -8,7 +8,8 @@ SCRIPTPATH=`dirname $0`
 SCRIPTPATH=`realpath $SCRIPTPATH`
 MODULE_FILE=$SCRIPTPATH/test_mod.c
 OBJ_MOD=$SCRIPTPATH/test_mod.o
-KERN_VER=`uname -r`
+KERNEL_DIR="${KERNEL_DIR:-/lib/modules/$(uname -r)/build/}"
+KERNEL_VER="$(cd $KERNEL_DIR; make kernelversion)"
 NPROC=`nproc`
 DEFINE_FILE=$SCRIPTPATH/../modules/generated_defines.h
 
@@ -43,7 +44,7 @@ compile_module(){
 	EOF
 	#######################################
 
-	make -C $SCRIPTPATH &> /dev/null
+	make -C $SCRIPTPATH KERNEL_DIR=${KERNEL_DIR} &> /dev/null
 
 	local ret=$?
 	if [ $ret -eq 0 ]; then

--- a/modules/Makefile
+++ b/modules/Makefile
@@ -20,7 +20,7 @@ VERSION_FILE=$(PWD)/CAS_VERSION
 OCFDIR=$(PWD)/../ocf
 KERNEL_DIR ?= "/lib/modules/$(shell uname -r)/build"
 PWD=$(shell pwd)
-KERNEL_VERSION := $(shell uname -r)
+KERNEL_VERSION := $(cd $KERNEL_DIR; make kernelversion)
 MODULES_DIR=/lib/modules/$(KERNEL_VERSION)/extra
 
 DISK_MODULE = cas_disk


### PR DESCRIPTION
KERNEL_DIR environment variable can be used to configure
and make CAS with custom kernel source path.

Signed-off-by: Adam Rutkowski <adam.j.rutkowski@intel.com>