### PR TITLE
Fix setting KERNEL_VERSION in modules makefile

### DIFF
--- a/modules/Makefile
+++ b/modules/Makefile
@@ -20,7 +20,7 @@ VERSION_FILE=$(PWD)/CAS_VERSION
 OCFDIR=$(PWD)/../ocf
 KERNEL_DIR ?= "/lib/modules/$(shell uname -r)/build"
 PWD=$(shell pwd)
-KERNEL_VERSION := $(cd $KERNEL_DIR; make kernelversion)
+KERNEL_VERSION := $(shell $(MAKE) -C $(KERNEL_DIR) --no-print-directory kernelversion)
 MODULES_DIR=/lib/modules/$(KERNEL_VERSION)/extra
 
 DISK_MODULE = cas_disk


### PR DESCRIPTION
Shell command evaluation should be performed using 'shell'
function. This fixes 'make install'.

Signed-off-by: Adam Rutkowski <adam.j.rutkowski@intel.com>