### PR TITLE
configure.d: fix detecting and usage of cas_blk_rq_append_bio

### DIFF
--- a/configure.d/1_append_bio.conf
+++ b/configure.d/1_append_bio.conf
@@ -6,11 +6,11 @@
 
 . `dirname $0`/conf_framework
 
-if compile_module "struct bio b;blk_rq_append_bio(NULL, &b)" "linux/blkdev.h"
+if compile_module "struct bio *b;blk_rq_append_bio(NULL, &b)" "linux/blkdev.h"
 then
     add_define "cas_blk_rq_append_bio(rq, bounce_bio) \\
-        blk_rq_append_bio(rq, bounce_bio)"
+        blk_rq_append_bio(rq, &bounce_bio)"
 else
     add_define "cas_blk_rq_append_bio(rq, bounce_bio) \\
-        blk_rq_append_bio(rq, &bounce_bio)"
+        blk_rq_append_bio(rq, bounce_bio)"
 fi

--- a/configure.d/2_make_req.conf
+++ b/configure.d/2_make_req.conf
@@ -28,7 +28,7 @@ static inline struct request *cas_blk_make_request(struct request_queue *q,
 		struct bio *bounce_bio = bio;
 		int ret;
 		cas_blk_queue_bounce(q, &bounce_bio);
-		ret = cas_blk_rq_append_bio(rq, &bounce_bio);
+		ret = cas_blk_rq_append_bio(rq, bounce_bio);
 		if (unlikely(ret)) {
 			blk_put_request(rq);
 			return ERR_PTR(ret);


### PR DESCRIPTION
1. When generating cas_blk_rq_append_bio, check whether a
   version with double pointer compiles successfully. This
   is a better criteria than the version with single pointer
   since the latter may compile successfully regardless of
   kernel blk_rq_append_bio prototype.
2. Always provide single pointer to cas_blk_rq_append_bio
   macro - its up to cas_blk_rq_append_bio implementation to
   decide whether extra level of indirection is needed.

This fixes compilation with kernel 4.14.98.

Signed-off-by: Adam Rutkowski <adam.j.rutkowski@intel.com>