### PR TITLE
Initialize structures with 0.

### DIFF
--- a/modules/cas_cache/layer_cache_management.c
+++ b/modules/cas_cache/layer_cache_management.c
@@ -972,6 +972,8 @@ int cache_mngt_prepare_cache_cfg(struct ocf_mngt_cache_config *cfg,
 		return -OCF_ERR_INVAL;
 
 	memset(cfg, 0, sizeof(*cfg));
+	memset(device_cfg, 0, sizeof(*device_cfg));
+	memset(atomic_params, 0, sizeof(*atomic_params));
 
 	cfg->id = cmd->cache_id;
 	cfg->cache_mode = cmd->caching_mode;
@@ -997,8 +999,9 @@ int cache_mngt_prepare_cache_cfg(struct ocf_mngt_cache_config *cfg,
 	init_cache = cmd->init_cache;
 
 	switch (init_cache) {
-	case CACHE_INIT_NEW:
 	case CACHE_INIT_LOAD:
+		device_cfg->open_cores = true;
+	case CACHE_INIT_NEW:
 		break;
 	default:
 		return -OCF_ERR_INVAL;

--- a/modules/cas_cache/service_ui_ioctl.c
+++ b/modules/cas_cache/service_ui_ioctl.c
@@ -61,7 +61,7 @@ long cas_service_ioctl_ctrl(struct file *filp, unsigned int cmd,
 		struct kcas_start_cache *cmd_info;
 		struct ocf_mngt_cache_config cfg;
 		struct ocf_mngt_cache_device_config device_cfg;
-		struct atomic_dev_params atomic_params = { 0 };
+		struct atomic_dev_params atomic_params;
 
 		GET_CMD_INFO(cmd_info, arg);
 


### PR DESCRIPTION
If 'open_cores' flag is not explicite set, cores migth not be added on cache
load.

Signed-off-by: Michal Mielewczyk <michal.mielewczyk@intel.com>