### PR TITLE
utils: Makefile: Rename default target to "all"

### DIFF
--- a/utils/Makefile
+++ b/utils/Makefile
@@ -29,7 +29,7 @@ endef
 endif
 
 # Just a placeholder when running make from parent dir without install/uninstall arg
-default: ;
+all: ;
 
 install:
 	@echo "Installing Open-CAS utils"


### PR DESCRIPTION
As "all" target is supported by upper level Makefile, and target
names are passed to subdirectory Makefiles, all of them need to
support "all" target as well. Rename default target for simplicity.

Signed-off-by: Robert Baldyga <robert.baldyga@intel.com>