### PR TITLE
Additional context ops: deinit. 

### DIFF
--- a/modules/cas_cache/context.c
+++ b/modules/cas_cache/context.c
@@ -430,13 +430,11 @@ int cas_initialize_context(void)
 	ret = atomic_dev_init();
 	if (ret) {
 		printk(KERN_ERR "Cannot initialize atomic device layer\n");
-		goto err_block_dev;
+		goto err_rpool;
 	}
 
 	return 0;
 
-err_block_dev:
-	block_dev_deinit();
 err_rpool:
 	cas_rpool_destroy(cas_bvec_pages_rpool, _cas_free_page_rpool, NULL);
 err_mpool:
@@ -449,8 +447,6 @@ err_ctx:
 
 void cas_cleanup_context(void)
 {
-	block_dev_deinit();
-	atomic_dev_deinit();
 	cas_garbage_collector_deinit();
 	cas_mpool_destroy(cas_bvec_pool);
 	cas_rpool_destroy(cas_bvec_pages_rpool, _cas_free_page_rpool, NULL);

--- a/modules/cas_cache/ocf_env.h
+++ b/modules/cas_cache/ocf_env.h
@@ -114,6 +114,10 @@ static inline int env_mutex_is_locked(env_mutex *mutex)
 	return mutex_is_locked(mutex);
 }
 
+static inline void env_mutex_destroy(env_mutex *mutex)
+{
+}
+
 /* *** RECURSIVE MUTEX *** */
 
 typedef struct {
@@ -197,6 +201,10 @@ static inline int env_rmutex_is_locked(env_rmutex *rmutex)
 	return mutex_is_locked(&rmutex->mutex);
 }
 
+static inline void env_rmutex_destroy(env_rmutex *rmutex)
+{
+}
+
 /* *** RW SEMAPHORE *** */
 
 typedef struct
@@ -261,6 +269,10 @@ static inline int env_rwsem_is_locked(env_rwsem *s)
 	return rwsem_is_locked(&s->sem);
 }
 
+static inline void env_rwsem_destroy(env_rwsem *s)
+{
+}
+
 /* *** COMPLETION *** */
 
 typedef struct completion env_completion;
@@ -278,6 +290,10 @@ static inline void env_completion_wait(env_completion *completion)
 static inline void env_completion_complete(env_completion *completion)
 {
 	complete(completion);
+}
+
+static inline void env_completion_destroy(env_completion *completion)
+{
 }
 
 /* *** ATOMIC VARIABLES *** */
@@ -429,6 +445,10 @@ static inline void env_spinlock_unlock_irq(env_spinlock *l)
 	spin_unlock_irq(l);
 }
 
+static inline void env_spinlock_destroy(env_spinlock *l)
+{
+}
+
 #define env_spinlock_lock_irqsave(l, flags) \
 		spin_lock_irqsave((l), (flags))
 
@@ -462,6 +482,10 @@ static inline void env_rwlock_write_lock(env_rwlock *l)
 static inline void env_rwlock_write_unlock(env_rwlock *l)
 {
 	write_unlock(l);
+}
+
+static inline void env_rwlock_destroy(env_rwlock *l)
+{
 }
 
 /* *** WAITQUEUE *** */

--- a/modules/cas_cache/volume/vol_atomic_dev_bottom.c
+++ b/modules/cas_cache/volume/vol_atomic_dev_bottom.c
@@ -1126,6 +1126,14 @@ error:
 	io->end(io, result);
 }
 
+static void atomic_dev_deinit(void)
+{
+	if (atomic_io_allocator) {
+		cas_mpool_destroy(atomic_io_allocator);
+		atomic_io_allocator = NULL;
+	}
+}
+
 const struct ocf_volume_properties cas_object_atomic_properties = {
 	.name = "Atomic Writes NVMe",
 	.io_priv_size = sizeof(struct blkio),
@@ -1148,6 +1156,7 @@ const struct ocf_volume_properties cas_object_atomic_properties = {
 		.set_data = cas_blk_io_set_data,
 		.get_data = cas_blk_io_get_data,
 	},
+	.deinit = atomic_dev_deinit
 };
 
 int atomic_dev_init(void)
@@ -1171,25 +1180,11 @@ int atomic_dev_init(void)
 	return 0;
 }
 
-void atomic_dev_deinit(void)
-{
-	if (atomic_io_allocator) {
-		cas_mpool_destroy(atomic_io_allocator);
-		atomic_io_allocator = NULL;
-	}
-
-	ocf_ctx_unregister_volume_type(cas_ctx, ATOMIC_DEVICE_VOLUME);
-}
-
 #else
 
 int atomic_dev_init(void)
 {
 	return 0;
-}
-
-void atomic_dev_deinit(void)
-{
 }
 
 #endif

--- a/modules/cas_cache/volume/vol_atomic_dev_bottom.h
+++ b/modules/cas_cache/volume/vol_atomic_dev_bottom.h
@@ -26,6 +26,4 @@ struct atomic_dev_params {
 
 int atomic_dev_init(void);
 
-void atomic_dev_deinit(void);
-
 #endif /* __VOL_ATOMIC_DEV_BOTTOM_H__ */

--- a/modules/cas_cache/volume/vol_block_dev_bottom.c
+++ b/modules/cas_cache/volume/vol_block_dev_bottom.c
@@ -565,6 +565,7 @@ const struct ocf_volume_properties cas_object_blk_properties = {
 		.set_data = cas_blk_io_set_data,
 		.get_data = cas_blk_io_get_data,
 	},
+	.deinit = NULL,
 };
 
 int block_dev_init(void)
@@ -577,10 +578,6 @@ int block_dev_init(void)
 		return ret;
 
 	return 0;
-}
-void block_dev_deinit(void)
-{
-	ocf_ctx_unregister_volume_type(cas_ctx, BLOCK_DEVICE_VOLUME);
 }
 
 int block_dev_try_get_io_class(struct bio *bio, int *io_class)

--- a/modules/cas_cache/volume/vol_block_dev_bottom.h
+++ b/modules/cas_cache/volume/vol_block_dev_bottom.h
@@ -21,6 +21,4 @@ int block_dev_try_get_io_class(struct bio *bio, int *io_class);
 
 int block_dev_init(void);
 
-void block_dev_deinit(void);
-
 #endif /* __VOL_BLOCK_DEV_BOTTOM_H__ */


### PR DESCRIPTION
While unloading cas_cache module, volume types were deinitialized, although core
pool still wasn't empty. Now this deinitialization can be done after removing
cores from core pool, and before contex is freed.

Signed-off-by: Michal Mielewczyk <michal.mielewczyk@intel.com>