### PR TITLE
Smoke tests update

### DIFF
--- a/test/smoke_test/cache_suspend/03
+++ b/test/smoke_test/cache_suspend/03
@@ -28,6 +28,10 @@ TEST_COUNT_HALF=16384
 #param device
 get_stat_sectors_read() {
     L_DEVICE=$(basename $1)
+    if [[  ${L_DEVICE} =~ "nvme" ]]
+    then
+        L_DEVICE="${L_DEVICE:0:${#L_DEVICE}-1}p${L_DEVICE: -1}"
+    fi
     L_STAT=$(cat /proc/diskstats | grep $L_DEVICE | awk '{ print $6 }')
     echo $L_STAT
 }

--- a/test/smoke_test/init_script/03
+++ b/test/smoke_test/init_script/03
@@ -65,7 +65,7 @@ run_cmd "dd if=/dev/urandom of=${DEVICE_NAME}1-2 count=1000 bs=4096 oflag=direct
 
 run_cmd "casctl stop --flush"
 
-run_cmd "casadm -S -d ${CACHE_DEVICE}1"
+run_cmd "casadm -S -d ${CACHE_DEVICE}1 --force"
 
 run_cmd "casctl stop"
 


### PR DESCRIPTION
**cache_suspend 03**: added if statement to recognize nvme disk and pass test correctly;
**init_script 03**: added '--force' option to start cache with 'casadm' command.

Signed-off-by: Slawomir_Jankowski <slawomir.jankowski@intel.com>