### PR TITLE
modules: Fixed getting running kernel ver

### DIFF
--- a/modules/Makefile
+++ b/modules/Makefile
@@ -20,8 +20,7 @@ VERSION_FILE=$(PWD)/CAS_VERSION
 OCFDIR=$(PWD)/../ocf
 KERNEL_DIR ?= "/lib/modules/$(shell uname -r)/build"
 PWD=$(shell pwd)
-KERNEL_VERSION := $(shell $(MAKE) -C $(KERNEL_DIR) --no-print-directory kernelversion)
-MODULES_DIR=/lib/modules/$(KERNEL_VERSION)/extra
+MODULES_DIR=/lib/modules/$(shell uname -r)/extra
 
 DISK_MODULE = cas_disk
 CACHE_MODULE = cas_cache


### PR DESCRIPTION
Kernel's 'make kernelversion' does not print some extra version tags
(like 4.19-xxx) so there was a problem with installing CAS on some
kernels. Moved it back to using just 'uname -r'.

Signed-off-by: Michal Rakowski <michal.rakowski@intel.com>