### PR TITLE
Change return type of env_rwsem_destroy().

### DIFF
--- a/modules/cas_cache/ocf_env.h
+++ b/modules/cas_cache/ocf_env.h
@@ -269,8 +269,9 @@ static inline int env_rwsem_is_locked(env_rwsem *s)
 	return rwsem_is_locked(&s->sem);
 }
 
-static inline void env_rwsem_destroy(env_rwsem *s)
+static inline int env_rwsem_destroy(env_rwsem *s)
 {
+	return 0;
 }
 
 /* *** COMPLETION *** */


### PR DESCRIPTION
OCF requires env_rwsem_destroy() to return int value.

Signed-off-by: Michal Mielewczyk <michal.mielewczyk@intel.com>