### PR TITLE
Fix env_strncpy.

### DIFF
--- a/modules/cas_cache/ocf_env.h
+++ b/modules/cas_cache/ocf_env.h
@@ -594,7 +594,7 @@ static inline void env_msleep(uint64_t n)
 #define env_strnlen(s, smax) strnlen(s, smax)
 #define env_strncmp strncmp
 #define env_strncpy(dest, dmax, src, slen) ({ \
-		strlcpy(dest, src, min_t(int, dmax, slen)); \
+		strlcpy(dest, src, min_t(int, dmax - 1, slen) + 1); \
 		0; \
 	})
 


### PR DESCRIPTION
strlcpy() requires room for terminating null to be included.

Signed-off-by: Michal Mielewczyk <michal.mielewczyk@intel.com>