### PR TITLE
Don't generate core name when adding core to corepool.

### DIFF
--- a/casadm/extended_err_msg.c
+++ b/casadm/extended_err_msg.c
@@ -62,6 +62,10 @@ struct {
 		"Too many core devices in cache"
 	},
 	{
+		OCF_ERR_CORE_EXIST,
+		"Core id already used"
+	},
+	{
 		OCF_ERR_CORE_NOT_AVAIL,
 		"Core device not available"
 	},


### PR DESCRIPTION
When core frome corepool is added to cache, it's old name is loaded and cores
in corepool cannot be referenced by name anyway so new name is not needed.

Fixes #124 

Signed-off-by: Michal Mielewczyk <michal.mielewczyk@intel.com>