### PR TITLE
Require python3 to install Open CAS Linux.

### DIFF
--- a/utils/Makefile
+++ b/utils/Makefile
@@ -7,6 +7,7 @@ CASCTL_DIR = /lib/opencas
 UDEVRULES_DIR = /lib/udev/rules.d
 UDEV:=$(shell which udevadm)
 SYSTEMCTL := $(shell which systemctl)
+PYTHON3 := $(shell which python3 &> /dev/null && echo 1)
 
 ifeq (, $(shell which systemctl))
 define cas_install
@@ -32,6 +33,9 @@ endif
 all: ;
 
 install:
+ifneq (1, $(PYTHON3))
+	$(error package 'python3' not found)
+else
 	@echo "Installing Open-CAS utils"
 
 	@install -m 755 -d $(CASCTL_DIR)
@@ -52,6 +56,7 @@ install:
 	@install -m 644 casctl.8 /usr/share/man/man8/casctl.8
 
 	$(cas_install)
+endif
 
 uninstall:
 	@rm $(CASCTL_DIR)/opencas.py


### PR DESCRIPTION
Fixes #127 

Signed-off-by: Michal Mielewczyk <michal.mielewczyk@intel.com>