### PR TITLE
configure: use blk_mq_end_request as a default instead of non-mq variant

### DIFF
--- a/configure.d/1_blk_end_req.conf
+++ b/configure.d/1_blk_end_req.conf
@@ -9,20 +9,23 @@
 check() {
 	cur_name=$(basename $2)
 	config_file_path=$1
-	if compile_module $cur_name "blk_end_request_all(NULL, 0)" "linux/blkdev.h"
+	if compile_module $cur_name "blk_mq_end_request(NULL, 0)" "linux/blk-mq.h"
 	then
 		echo $cur_name "1" >> $config_file_path
-	else
+	elif compile_module $cur_name "blk_end_request_all(NULL, 0)" "linux/blkdev.h"
+	then
 		echo $cur_name "2" >> $config_file_path
-    fi
+	else
+		echo $cur_name "X" >> $config_file_path
+	fi
 }
 
 apply() {
     case "$1" in
     "1")
-		add_define "CAS_END_REQUEST_ALL blk_end_request_all" ;;
-    "2")
 		add_define "CAS_END_REQUEST_ALL blk_mq_end_request" ;;
+    "2")
+		add_define "CAS_END_REQUEST_ALL blk_end_request_all" ;;
     *)
         exit 1
     esac

--- a/modules/cas_cache/linux_kernel_version.h
+++ b/modules/cas_cache/linux_kernel_version.h
@@ -38,6 +38,7 @@
 #include <linux/nmi.h>
 #include <linux/ratelimit.h>
 #include <linux/mm.h>
+#include <linux/blk-mq.h>
 
 #include "generated_defines.h"
 


### PR DESCRIPTION
Fixes #128 

Signed-off-by: Michal Rakowski <michal.rakowski@intel.com>