### PR TITLE
Add .gitignore for functional tests

### DIFF
--- a/test/functional/.gitignore
+++ b/test/functional/.gitignore
@@ -1,0 +1,1 @@
+plugins/


### PR DESCRIPTION
Ignore changes in plugins/ directory. This directory is for user plugins
which should not be added to Open CAS Linux repository.

Signed-off-by: Robert Baldyga <robert.baldyga@intel.com>