### PR TITLE
Enable logging mechanism and example of logger usage in one test

### DIFF
--- a/test/functional/.gitignore
+++ b/test/functional/.gitignore
@@ -1,1 +1,2 @@
 plugins/
+results/

--- a/test/functional/pytest.ini
+++ b/test/functional/pytest.ini
@@ -1,9 +1,2 @@
 [pytest]
-log_cli = 1
-log_cli_level = INFO
-log_cli_format = %(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)
-log_cli_date_format=%Y-%m-%d %H:%M:%S
-log_file = pytest.log
-log_file_level = INFO
-log_file_format = %(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)
-log_file_date_format=%Y-%m-%d %H:%M:%S
+addopts = -s


### PR DESCRIPTION
Logging mechanism enabled in one example test.
Creating logs enabled in conftest.
Gathering additional logs at the end of test.
Created cleanup method (teardown) in conftest, which is executed at the end of each test, even if test  was interrupted/failed.