### PR TITLE
Make __block_dev_get_elevator_name return const string

### DIFF
--- a/modules/cas_cache/volume/vol_block_dev_bottom.c
+++ b/modules/cas_cache/volume/vol_block_dev_bottom.c
@@ -92,7 +92,7 @@ uint64_t block_dev_get_byte_length(ocf_volume_t vol)
 }
 
 #if LINUX_VERSION_CODE <= KERNEL_VERSION(3, 3, 0)
-static char *__block_dev_get_elevator_name(struct request_queue *q)
+static const char *__block_dev_get_elevator_name(struct request_queue *q)
 {
 	if (q->elevator->elevator_type == NULL)
 		return NULL;
@@ -106,7 +106,7 @@ static char *__block_dev_get_elevator_name(struct request_queue *q)
 	return q->elevator->elevator_type->elevator_name;
 }
 #else
-static char *__block_dev_get_elevator_name(struct request_queue *q)
+static const char *__block_dev_get_elevator_name(struct request_queue *q)
 {
 	if (q->elevator->type == NULL)
 		return NULL;


### PR DESCRIPTION
Returning non-const char* doesn't have any benefits since
the only caller casts the output pointer to const char *.

This change fixes compilation on 5.3 kernel.

Signed-off-by: Adam Rutkowski <adam.j.rutkowski@intel.com>