### PR TITLE
Use git utils from cas API

### DIFF
--- a/test/functional/api/cas/git.py
+++ b/test/functional/api/cas/git.py
@@ -1,0 +1,21 @@
+#
+# Copyright(c) 2019 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+#
+
+from core.test_run import TestRun
+from connection.local_executor import LocalExecutor
+
+
+def get_current_commit_hash():
+    local_executor = LocalExecutor()
+    return local_executor.run(
+        f"cd {TestRun.plugins['opencas']['repo_dir']} &&"
+        f'git show HEAD --pretty=format:"%H"').stdout
+
+
+def get_current_commit_message():
+    local_executor = LocalExecutor()
+    return local_executor.run(
+        f"cd {TestRun.plugins['opencas']['repo_dir']} &&"
+        f'git show HEAD --pretty=format:"%s"').stdout

--- a/test/functional/tests/conftest.py
+++ b/test/functional/tests/conftest.py
@@ -15,9 +15,9 @@ sys.path.append(os.path.join(os.path.dirname(__file__), "../test-framework"))
 from core.test_run_utils import TestRun
 from api.cas import installer
 from api.cas import casadm
+from api.cas import git
 from test_utils.os_utils import Udev
 from log.logger import create_log
-from test_utils import git_utils
 
 plugins_dir = os.path.join(os.path.dirname(__file__), "../plugins")
 sys.path.append(plugins_dir)
@@ -181,6 +181,6 @@ def base_prepare(item):
             installer.install_opencas()
         TestRun.plugins['opencas']['already_updated'] = True
         TestRun.LOGGER.add_build_info(f'Commit hash:')
-        TestRun.LOGGER.add_build_info(f"{git_utils.get_current_commit_hash()}")
+        TestRun.LOGGER.add_build_info(f"{git.get_current_commit_hash()}")
         TestRun.LOGGER.add_build_info(f'Commit message:')
-        TestRun.LOGGER.add_build_info(f'{git_utils.get_current_commit_message()}')
+        TestRun.LOGGER.add_build_info(f'{git.get_current_commit_message()}')


### PR DESCRIPTION
Test framework does no longer provide git_utils, so we switch
to local implementation.

Signed-off-by: Robert Baldyga <robert.baldyga@intel.com>