### PR TITLE
tests: Don't call base_prepare() in tests

### DIFF
--- a/test/functional/tests/cli/test_cli_help.py
+++ b/test/functional/tests/cli/test_cli_help.py
@@ -7,7 +7,6 @@
 import logging
 import pytest
 from api.cas import casadm
-from tests.conftest import base_prepare
 
 
 LOGGER = logging.getLogger(__name__)
@@ -15,14 +14,9 @@ LOGGER = logging.getLogger(__name__)
 
 @pytest.mark.parametrize("shortcut", [True, False])
 def test_cli_help(shortcut):
-    prepare()
     LOGGER.info("Test run")
     output = casadm.help(shortcut)
     LOGGER.info(output.stdout)  # TODO:this is tmp, every ssh command shall be logged via executor
     assert output.stdout[0:33] == "Cache Acceleration Software Linux"
     # TODO: create yml config for every help command and match the output with it
     # TODO: for now the assert above is purely for testing flow in the casadm api
-
-
-def prepare():
-    base_prepare()

--- a/test/functional/tests/example/example_test.py
+++ b/test/functional/tests/example/example_test.py
@@ -8,7 +8,6 @@ from test_tools.disk_utils import Filesystem
 from test_utils.size import Size, Unit
 from core.test_run import TestRun
 from storage_devices.disk import DiskType, DiskTypeSet
-from tests.conftest import base_prepare
 from test_utils.filesystem.file import File
 from test_utils.filesystem.directory import Directory
 from test_tools import fs_utils
@@ -20,7 +19,6 @@ def setup_module():
 
 @pytest.mark.require_disk("cache", DiskTypeSet([DiskType.optane, DiskType.nand]))
 def test_create_example_partitions():
-    prepare()
     TestRun.LOGGER.info("Test run")
     TestRun.LOGGER.info(f"DUT info: {TestRun.dut}")
     test_disk = TestRun.disks['cache']
@@ -33,7 +31,6 @@ def test_create_example_partitions():
 
 
 def test_create_example_files():
-    prepare()
     TestRun.LOGGER.info("Test run")
     file1 = File.create_file("example_file")
     file1.write("Test file\ncontent line\ncontent")
@@ -56,6 +53,3 @@ def test_create_example_files():
         TestRun.LOGGER.info(f"Item {str(item)} - {type(item).__name__}")
     fs_utils.remove(file1.full_path, True)
 
-
-def prepare():
-    base_prepare()

--- a/test/functional/tests/inactive_core/test_inactive_cores.py
+++ b/test/functional/tests/inactive_core/test_inactive_cores.py
@@ -6,7 +6,6 @@
 
 import pytest
 from core.test_run import TestRun
-from tests.conftest import base_prepare
 from storage_devices.disk import DiskType, DiskTypeSet, DiskTypeLowerThan
 from test_utils.size import Size, Unit
 from api.cas.cache_config import CacheMode
@@ -133,7 +132,6 @@ def test_core_inactive_stats():
 
 
 def prepare():
-    base_prepare()
     cache_device = TestRun.disks['cache']
     core_device = TestRun.disks['core']
 

--- a/test/functional/tests/load/test_load.py
+++ b/test/functional/tests/load/test_load.py
@@ -6,7 +6,6 @@
 
 import pytest
 from api.cas import casadm, casadm_parser
-from tests.conftest import base_prepare
 from core.test_run import TestRun
 from storage_devices.disk import DiskType, DiskTypeSet, DiskTypeLowerThan
 from test_utils.size import Size, Unit
@@ -23,7 +22,6 @@ def test_load_occupied_id():
         5. Try to load metadata from first device.
             * Load should fail.
     """
-    prepare()
 
     cache_device = TestRun.disks['cache']
     core_device = TestRun.disks['core']
@@ -59,7 +57,3 @@ def test_load_occupied_id():
 
     cores = caches[0].get_core_devices()
     assert len(cores) == 0
-
-
-def prepare():
-    base_prepare()

--- a/test/functional/tests/stats/test_block_stats.py
+++ b/test/functional/tests/stats/test_block_stats.py
@@ -10,7 +10,6 @@ from api.cas import casadm
 from api.cas import ioclass_config
 from test_tools.dd import Dd
 from api.cas.cache_config import CacheMode, CleaningPolicy
-from tests.conftest import base_prepare
 from core.test_run import TestRun
 from storage_devices.disk import DiskType, DiskTypeSet, DiskTypeLowerThan
 from test_utils.size import Size, Unit
@@ -290,7 +289,6 @@ def flush(cache):
 
 
 def prepare(cache_mode: CacheMode):
-    base_prepare()
     ioclass_config.remove_ioclass_config()
     cache_device = TestRun.disks['cache']
     core_device = TestRun.disks['core']

--- a/test/functional/tests/stats/test_ioclass_stats.py
+++ b/test/functional/tests/stats/test_ioclass_stats.py
@@ -10,7 +10,6 @@ from api.cas import casadm
 from api.cas import ioclass_config
 from api.cas import casadm_parser
 from api.cas.cache_config import CleaningPolicy
-from tests.conftest import base_prepare
 from core.test_run import TestRun
 from storage_devices.disk import DiskType, DiskTypeSet, DiskTypeLowerThan
 from test_tools.disk_utils import Filesystem
@@ -144,7 +143,6 @@ def flush_cache(cache_id):
 
 
 def prepare():
-    base_prepare()
     ioclass_config.remove_ioclass_config()
     cache_device = TestRun.disks['cache']
     core_device = TestRun.disks['core']


### PR DESCRIPTION
The base_prepare() function is now called automatically during test
setup so there is no longer need to call it from each test manually.

Signed-off-by: Robert Baldyga <robert.baldyga@intel.com>