### PR TITLE
Wait for cas_ctrl device in casctl

### DIFF
--- a/utils/casctl
+++ b/utils/casctl
@@ -191,4 +191,5 @@ class cas:
         stop(args.flush)
 
 if __name__ == '__main__':
+    opencas.wait_for_cas_ctrl()
     cas()

--- a/utils/open-cas-loader
+++ b/utils/open-cas-loader
@@ -11,12 +11,6 @@ import sys
 import os
 import syslog as sl
 
-def wait_for_cas_ctrl():
-    for i in range(30): # timeout 30s
-        if os.path.exists('/dev/cas_ctrl'):
-            return
-        time.sleep(1)
-
 try:
     subprocess.call(['/sbin/modprobe', 'cas_cache'])
 except:
@@ -34,7 +28,7 @@ except Exception as e:
 for cache in config.caches.values():
     if sys.argv[1] == os.path.realpath(cache.device):
         try:
-            wait_for_cas_ctrl()
+            opencas.wait_for_cas_ctrl()
             opencas.start_cache(cache, True)
         except opencas.casadm.CasadmError as e:
             sl.syslog(sl.LOG_WARNING,
@@ -45,7 +39,7 @@ for cache in config.caches.values():
     for core in cache.cores.values():
         if sys.argv[1] == os.path.realpath(core.device):
             try:
-                wait_for_cas_ctrl()
+                opencas.wait_for_cas_ctrl()
                 opencas.add_core(core, True)
             except opencas.casadm.CasadmError as e:
                 sl.syslog(sl.LOG_WARNING,

--- a/utils/opencas.py
+++ b/utils/opencas.py
@@ -768,6 +768,13 @@ def get_devices_state():
     return devices
 
 
+def wait_for_cas_ctrl():
+    for i in range(30):  # timeout 30s
+        if os.path.exists('/dev/cas_ctrl'):
+            return
+        time.sleep(1)
+
+
 def wait_for_startup(timeout=300, interval=5):
     try:
         config = cas_config.from_file(


### PR DESCRIPTION
Wait for cas_ctrl device to make sure it's availble when calling casctl commands.

Signed-off-by: Jan Musial <jan.musial@intel.com>