### PR TITLE
Try to load devices on change udev event

### DIFF
--- a/utils/60-persistent-storage-cas-load.rules
+++ b/utils/60-persistent-storage-cas-load.rules
@@ -1,4 +1,4 @@
-ACTION!="add", GOTO="cas_loader_end"
+ACTION=="remove", GOTO="cas_loader_end"
 SUBSYSTEM!="block", GOTO="cas_loader_end"
 
 RUN+="/lib/opencas/open-cas-loader /dev/$name"


### PR DESCRIPTION
This fixes CAS-on-LVM scenario. Currently how we work:
1. LVM instantinates device nodes (not usable at this point)
2. CAS tries to add cores (fails)
3. LVM ends device configuration and issues change uevent
4. We ignore change uevents so we do nothing

This patch makes sure we don't ignore change uevents.
Still, some messages about not being able to open core device
can show up in syslog - there's room for improvement.

Signed-off-by: Jan Musial <jan.musial@intel.com>