### PR TITLE
tests: Add missing import pytests in conftest.py

### DIFF
--- a/test/functional/tests/conftest.py
+++ b/test/functional/tests/conftest.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 #
 
+import pytest
 import os
 import sys
 import yaml


### PR DESCRIPTION
Signed-off-by: Robert Baldyga <robert.baldyga@intel.com>