### PR TITLE
utils: casctl needs python 3.5+

### DIFF
--- a/utils/casctl
+++ b/utils/casctl
@@ -9,6 +9,9 @@ import sys
 import re
 import opencas
 
+if sys.version_info < (3, 5):
+    raise RuntimeError('At least Python 3.5 is required')
+
 def eprint(*args, **kwargs):
     print(*args, file=sys.stderr, **kwargs)
 


### PR DESCRIPTION
opencas.py invokes subprocess.run().
Only python 3.5 and later versions support subprocess.run().

Signed-off-by: liuhongtong <hongtongliu@126.com>