### PR TITLE
Add FI test: try add twice the same device as core

### DIFF
--- a/test/functional/api/cas/cli_messages.py
+++ b/test/functional/api/cas/cli_messages.py
@@ -25,10 +25,23 @@ stop_cache_incomplete = [
     r"Cache is in incomplete state - at least one core is inactive"
 ]
 
+add_cached_core = [
+    r"Error while adding core device to cache instance \d+",
+    r"Core device \'/dev/\S+\' is already cached\."
+]
+
+remove_mounted_core = [
+    r"Can\'t remove core \d+ from cache \d+\. Device /dev/cas\d+-\d+ is mounted\!"
+]
+
+stop_cache_mounted_core = [
+    r"Can\'t stop cache instance \d+\. Device /dev/cas\d+-\d+ is mounted\!"
+]
+
 
 def check_msg(output: Output, expected_messages):
     result = '\n'.join([output.stdout, output.stderr])
     for msg in expected_messages:
         matches = re.search(msg, result)
         if not matches:
-            TestRun.fail(f"Message is incorrect, expected: {msg}\n actual: {result}.")
+            TestRun.LOGGER.error(f"Message is incorrect, expected: {msg}\n actual: {result}.")

--- a/test/functional/tests/fault_injection/test_fault_injection_with_mounted_core.py
+++ b/test/functional/tests/fault_injection/test_fault_injection_with_mounted_core.py
@@ -5,13 +5,12 @@
 
 import pytest
 
-from api.cas import casadm, casadm_parser, cli
+from api.cas import casadm, casadm_parser, cli, cli_messages
 from api.cas.cache_config import CacheMode
 from storage_devices.disk import DiskType, DiskTypeSet, DiskTypeLowerThan
 from core.test_run import TestRun
 from test_tools import fs_utils
 from test_tools.disk_utils import Filesystem
-from test_utils.filesystem.file import File
 from test_utils.size import Size, Unit
 
 mount_point = "/mnt/cas"
@@ -34,22 +33,20 @@ def test_load_cache_with_mounted_core(cache_mode):
     with TestRun.step("Prepare cache and core devices. Start CAS."):
         cache_dev = TestRun.disks['cache']
         cache_dev.create_partitions([Size(1, Unit.GibiByte)])
-        cache_dev = cache_dev.partitions[0]
+        cache_part = cache_dev.partitions[0]
         core_dev = TestRun.disks['core']
         core_dev.create_partitions([Size(4, Unit.GibiByte)])
-        core_dev = core_dev.partitions[0]
-        cache = casadm.start_cache(cache_dev, cache_mode, force=True)
+        core_part = core_dev.partitions[0]
+        cache = casadm.start_cache(cache_part, cache_mode, force=True)
 
-    with TestRun.step("Add core device with xfs filesystem and mount it."):
-        core_dev.create_filesystem(Filesystem.xfs)
-        core = cache.add_core(core_dev)
+    with TestRun.step("Add core device with xfs filesystem to cache and mount it."):
+        core_part.create_filesystem(Filesystem.xfs)
+        core = cache.add_core(core_part)
         core.mount(mount_point)
 
-    with TestRun.step(f"Create test file in /tmp directory."):
-        file = fs_utils.create_test_file('/tmp/test_file')
-
-    with TestRun.step("Copy file to cache's exported object"):
-        copied_file = File.copy(file.full_path, test_file_path, force=True)
+    with TestRun.step(f"Create test file in mount point of exported object and check its md5 sum."):
+        test_file = fs_utils.create_random_test_file(test_file_path)
+        test_file_md5_before = test_file.md5sum()
 
     with TestRun.step("Unmount core device."):
         core.unmount()
@@ -61,9 +58,9 @@ def test_load_cache_with_mounted_core(cache_mode):
             TestRun.fail(f"Expected caches count: 0; Actual caches count: {caches_count}.")
 
     with TestRun.step("Mount core device."):
-        core_dev.mount(mount_point)
+        core_part.mount(mount_point)
 
-    with TestRun.step("Load cache."):
+    with TestRun.step("Try to load cache."):
         cache = casadm.load_cache(cache.cache_device)
         caches_count = len(casadm_parser.get_caches())
         if caches_count != 1:
@@ -72,12 +69,12 @@ def test_load_cache_with_mounted_core(cache_mode):
         if cores_count != 0:
             TestRun.fail(f"Expected cores count: 0; Actual cores count: {cores_count}.")
 
-    with TestRun.step("Check properties of test file."):
-        if file.get_properties() != copied_file.get_properties():
-            TestRun.LOGGER.error("File properties before and after copying are different.")
-        core_dev.unmount()
+    with TestRun.step("Check md5 sum of test file again."):
+        if test_file_md5_before != test_file.md5sum():
+            TestRun.LOGGER.error("Md5 sum of test file is different.")
+        core_part.unmount()
 
-    with TestRun.step("Stop all caches."):
+    with TestRun.step("Stop cache."):
         casadm.stop_all_caches()
 
 
@@ -92,77 +89,81 @@ def test_stop_cache_with_mounted_partition(cache_mode):
           is still mounted.
         pass_criteria:
           - No system crash.
-          - Unable to stop CAS device.
+          - Unable to stop cache when partition is mounted.
           - Unable to remove core when partition is mounted.
     """
     with TestRun.step("Prepare cache and core devices. Start CAS."):
         cache_dev = TestRun.disks['cache']
         cache_dev.create_partitions([Size(1, Unit.GibiByte)])
-        cache_dev = cache_dev.partitions[0]
+        cache_part = cache_dev.partitions[0]
         core_dev = TestRun.disks['core']
         core_dev.create_partitions([Size(4, Unit.GibiByte)])
-        core_dev = core_dev.partitions[0]
-        cache = casadm.start_cache(cache_dev, cache_mode, force=True)
+        core_part = core_dev.partitions[0]
+        cache = casadm.start_cache(cache_part, cache_mode, force=True)
 
     with TestRun.step("Add core device with xfs filesystem and mount it."):
-        core_dev.create_filesystem(Filesystem.xfs)
-        core = cache.add_core(core_dev)
+        core_part.create_filesystem(Filesystem.xfs)
+        core = cache.add_core(core_part)
         core.mount(mount_point)
 
     with TestRun.step("Try to remove core from cache."):
         output = TestRun.executor.run_expect_fail(cli.remove_core_cmd(cache_id=str(cache.cache_id),
                                                                       core_id=str(core.core_id)))
-        if not output.stderr:
-            TestRun.fail("Removing core succeeded (should fail)!")
+        cli_messages.check_msg(output, cli_messages.remove_mounted_core)
 
     with TestRun.step("Try to stop CAS."):
         output = TestRun.executor.run_expect_fail(cli.stop_cmd(cache_id=str(cache.cache_id)))
-        if not output.stderr:
-            TestRun.fail("Stopping CAS succeeded (should fail)!")
+        cli_messages.check_msg(output, cli_messages.stop_cache_mounted_core)
 
     with TestRun.step("Unmount core device."):
         core.unmount()
 
-    with TestRun.step("Stop all caches."):
+    with TestRun.step("Stop cache."):
         casadm.stop_all_caches()
 
 
 @pytest.mark.parametrize("cache_mode", CacheMode)
 @pytest.mark.require_disk("cache", DiskTypeSet([DiskType.optane, DiskType.nand]))
 @pytest.mark.require_disk("core", DiskTypeLowerThan("cache"))
-def test_add_occupied_core(cache_mode):
+def test_add_cached_core(cache_mode):
     """
         title: Fault injection test for adding already used core to a cache.
         description: |
-          Negative test of the ability to add core to cache
-          while the core is already used by the another cache instance.
+          Negative test of the ability to add the core to the cache twice to the same cache
+          and while the core is already used by the another cache instance.
         pass_criteria:
+          - No system crash.
           - Adding already used core to another cache instance fails.
+          - The same core device cannot be used twice in one cache instance.
     """
     with TestRun.step("Prepare two caches and one core device."):
         cache_dev = TestRun.disks['cache']
         cache_dev.create_partitions([Size(2, Unit.GibiByte), Size(2, Unit.GibiByte)])
-        cache_dev1 = cache_dev.partitions[0]
-        cache_dev2 = cache_dev.partitions[1]
+        cache_part1 = cache_dev.partitions[0]
+        cache_part2 = cache_dev.partitions[1]
         core_dev = TestRun.disks['core']
         core_dev.create_partitions([Size(4, Unit.GibiByte)])
-        core_dev = core_dev.partitions[0]
+        core_part = core_dev.partitions[0]
 
-    with TestRun.step("Start first cache instance"):
-        cache1 = casadm.start_cache(cache_dev1, cache_mode, force=True)
+    with TestRun.step("Start the first cache instance"):
+        cache1 = casadm.start_cache(cache_part1, cache_mode, force=True)
 
     with TestRun.step("Add core device to first cache instance."):
-        core = cache1.add_core(core_dev)
+        core = cache1.add_core(core_part)
 
-    with TestRun.step("Start second cache instance"):
-        cache2 = casadm.start_cache(cache_dev2, cache_mode, force=True)
+    with TestRun.step("Start the second cache instance"):
+        cache2 = casadm.start_cache(cache_part2, cache_mode, force=True)
 
-    with TestRun.step("Try adding the same core device to second cache instance."):
-        output = TestRun.executor.run_expect_fail(cli.add_core_cmd(cache_id=str(cache2.cache_id),
-                                                                   core_dev=str(core_dev),
-                                                                   core_id=str(core.core_id)))
-        if not output.stderr:
-            TestRun.fail("Adding same core to other cache succeeded (should fail)!")
+    with TestRun.step("Try adding the same core device to the second cache instance."):
+        output = TestRun.executor.run_expect_fail(
+            cli.add_core_cmd(cache_id=str(cache2.cache_id), core_dev=str(core_part.system_path),
+                             core_id=str(core.core_id)))
+        cli_messages.check_msg(output, cli_messages.add_cached_core)
 
-    with TestRun.step("Stop all caches."):
+    with TestRun.step("Try adding the same core device to the same cache for the second time."):
+        output = TestRun.executor.run_expect_fail(
+            cli.add_core_cmd(cache_id=str(cache1.cache_id), core_dev=str(core_part.system_path)))
+        cli_messages.check_msg(output, cli_messages.add_cached_core)
+
+    with TestRun.step("Stop caches."):
         casadm.stop_all_caches()


### PR DESCRIPTION
Check that OpenCAS does not accepts twice the same device as core.

Signed-off-by: Slawomir_Jankowski <slawomir.jankowski@intel.com>