### PR TITLE
Modify error message

### DIFF
--- a/configure
+++ b/configure
@@ -27,7 +27,7 @@ check_util lsblk
 
 if [ ! -e /lib/modules/$(uname -r)/build/ &> /dev/null ]
 then
-	echo >&2 "Error: missing kernel headers"
+	echo >&2 "Error: missing kernel headers and/or kernel devel"
 	MISSING_TOOLS=1
 fi
 


### PR DESCRIPTION
There is no generic way to check apart presence of kernel headers and kernel devel packages.
If we know system, we could use package manager, but without this knowledge,
we can't distinguish which headers in kernel headers directory belongs to which package.
Resolves #280 issue

Signed-off-by: Slawomir Jankowski <slawomir.jankowski@intel.com>