### PR TITLE
cas_cache: use underscore instead of space in volume type name

### DIFF
--- a/modules/cas_cache/volume/vol_atomic_dev_bottom.c
+++ b/modules/cas_cache/volume/vol_atomic_dev_bottom.c
@@ -1135,7 +1135,7 @@ static void atomic_dev_deinit(void)
 }
 
 const struct ocf_volume_properties cas_object_atomic_properties = {
-	.name = "Atomic Writes NVMe",
+	.name = "Atomic_Writes_NVMe",
 	.io_priv_size = sizeof(struct blkio),
 	.volume_priv_size = sizeof(struct bd_object),
 	.caps = {

--- a/modules/cas_cache/volume/vol_block_dev_bottom.c
+++ b/modules/cas_cache/volume/vol_block_dev_bottom.c
@@ -545,7 +545,7 @@ static void block_dev_submit_io(struct ocf_io *io)
 }
 
 const struct ocf_volume_properties cas_object_blk_properties = {
-	.name = "Block Device",
+	.name = "Block_Device",
 	.io_priv_size = sizeof(struct blkio),
 	.volume_priv_size = sizeof(struct bd_object),
 	.caps = {


### PR DESCRIPTION
Fixes https://github.com/Open-CAS/open-cas-linux/issues/243 

Signed-off-by: Michal Rakowski <michal.rakowski@intel.com>
