### PR TITLE
Fix Python multiplication issue

### DIFF
--- a/test/functional/api/cas/cache.py
+++ b/test/functional/api/cas/cache.py
@@ -177,7 +177,7 @@ class Cache:
                                               if alru_params.staleness_time else None,
                                               alru_params.flush_max_buffers
                                               if alru_params.flush_max_buffers else None,
-                                              int(alru_params.activity_threshold.total_seconds()
+                                              round(alru_params.activity_threshold.total_seconds()
                                                   * 1000)
                                               if alru_params.activity_threshold else None)
 

--- a/test/functional/api/cas/cache_config.py
+++ b/test/functional/api/cas/cache_config.py
@@ -81,7 +81,7 @@ class CacheStatus(Enum):
 
 class Time(timedelta):
     def total_milliseconds(self):
-        return int(self.total_seconds() * 1000)
+        return round(self.total_seconds() * 1000)
 
 
 class FlushParametersAlru:


### PR DESCRIPTION
When some particular values are multplied by 10^n, Python returns float
number with subtracted value of (size of float)^-1
For example: 1.017 * 1000 = 1016.(9)
Rounding the output value fixes this issue.

Signed-off-by: Rafal Stefanowski <rafal.stefanowski@intel.com>