### PR TITLE
Refactor statistics

### DIFF
--- a/test/functional/api/cas/cache.py
+++ b/test/functional/api/cas/cache.py
@@ -3,12 +3,9 @@
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 #
 
-from api.cas.cache_config import *
-from api.cas.casadm_params import *
 from api.cas.casadm_parser import *
 from api.cas.cli import *
 from api.cas.statistics import CacheStats, IoClassStats
-from core.test_run import TestRun
 from storage_devices.device import Device
 from test_utils.os_utils import *
 
@@ -108,13 +105,10 @@ class Cache:
                                stat_filter, percentage_val)
         return CacheStats(stats)
 
-    # TODO: Get rid of this method below by tuning 'stats' and 'io_class' tests
-    # to utilize new statistics API with method above.
-
-    def get_statistics_deprecated(self,
-                                  io_class_id: int = None,
-                                  stat_filter: List[StatsFilter] = None,
-                                  percentage_val: bool = False):
+    def get_statistics_flat(self,
+                            io_class_id: int = None,
+                            stat_filter: List[StatsFilter] = None,
+                            percentage_val: bool = False):
         return get_statistics(self.cache_id, None, io_class_id,
                               stat_filter, percentage_val)
 

--- a/test/functional/api/cas/core.py
+++ b/test/functional/api/cas/core.py
@@ -4,9 +4,6 @@
 #
 
 
-from datetime import timedelta
-
-from api.cas.cache import Device
 from api.cas.casadm_parser import *
 from api.cas.cli import *
 from api.cas.statistics import CoreStats, IoClassStats
@@ -67,13 +64,10 @@ class Core(Device):
                                stat_filter, percentage_val)
         return CoreStats(stats)
 
-    # TODO: Get rid of this method below by tuning 'stats' and 'io_class' tests
-    # to utilize new statistics API with method above.
-
-    def get_statistics_deprecated(self,
-                                  io_class_id: int = None,
-                                  stat_filter: List[StatsFilter] = None,
-                                  percentage_val: bool = False):
+    def get_statistics_flat(self,
+                            io_class_id: int = None,
+                            stat_filter: List[StatsFilter] = None,
+                            percentage_val: bool = False):
         return get_statistics(self.cache_id, self.core_id, io_class_id,
                               stat_filter, percentage_val)
 

--- a/test/functional/tests/stats/test_block_stats.py
+++ b/test/functional/tests/stats/test_block_stats.py
@@ -5,15 +5,16 @@
 
 
 import pytest
-from api.cas.casadm import StatsFilter
+
 from api.cas import casadm
 from api.cas import ioclass_config
-from test_tools.dd import Dd
 from api.cas.cache_config import CacheMode, CleaningPolicy
+from api.cas.casadm import StatsFilter
 from core.test_run import TestRun
 from storage_devices.disk import DiskType, DiskTypeSet, DiskTypeLowerThan
-from test_utils.size import Size, Unit
+from test_tools.dd import Dd
 from test_utils.os_utils import Udev
+from test_utils.size import Size, Unit
 
 ioclass_config_path = "/tmp/opencas_ioclass.conf"
 mountpoint = "/tmp/cas1-1"
@@ -112,8 +113,8 @@ def test_block_stats_write(cache_mode, zero_stats):
         for i in range(iterations):
             dd.seek(dd_seek)
             dd.run()
-            cache_stats = cache.get_statistics_deprecated(stat_filter=[StatsFilter.blk])
-            core_stats = core.get_statistics_deprecated(stat_filter=[StatsFilter.blk])
+            cache_stats = cache.get_statistics_flat(stat_filter=[StatsFilter.blk])
+            core_stats = core.get_statistics_flat(stat_filter=[StatsFilter.blk])
 
             # Check cache stats
             assumed_value = (dd_size.get_value(Unit.Blocks4096) * dd_count) * (i + 1)
@@ -237,8 +238,8 @@ def test_block_stats_read(cache_mode, zero_stats):
         for i in range(iterations):
             dd.skip(dd_skip)
             dd.run()
-            cache_stats = cache.get_statistics_deprecated(stat_filter=[StatsFilter.blk])
-            core_stats = core.get_statistics_deprecated(stat_filter=[StatsFilter.blk])
+            cache_stats = cache.get_statistics_flat(stat_filter=[StatsFilter.blk])
+            core_stats = core.get_statistics_flat(stat_filter=[StatsFilter.blk])
 
             # Check cache stats
             assumed_value = (dd_size.get_value(Unit.Blocks4096) * dd_count) * (i + 1)
@@ -283,7 +284,7 @@ def test_block_stats_read(cache_mode, zero_stats):
 def flush(cache):
     cache.flush_cache()
     cache.reset_counters()
-    stats = cache.get_statistics_deprecated(stat_filter=[StatsFilter.blk])
+    stats = cache.get_statistics_flat(stat_filter=[StatsFilter.blk])
     for key, value in stats.items():
         assert value.get_value(Unit.Blocks4096) == 0
 

--- a/test/functional/tests/stats/test_ioclass_stats.py
+++ b/test/functional/tests/stats/test_ioclass_stats.py
@@ -5,17 +5,18 @@
 
 
 import pytest
-from api.cas.casadm import StatsFilter
+
 from api.cas import casadm
-from api.cas import ioclass_config
 from api.cas import casadm_parser
+from api.cas import ioclass_config
 from api.cas.cache_config import CleaningPolicy
+from api.cas.casadm import StatsFilter
 from core.test_run import TestRun
 from storage_devices.disk import DiskType, DiskTypeSet, DiskTypeLowerThan
 from test_tools.disk_utils import Filesystem
-from test_utils.size import Size, Unit
-from test_utils.os_utils import sync, Udev
 from test_utils.filesystem.file import File
+from test_utils.os_utils import sync, Udev
+from test_utils.size import Size, Unit
 
 ioclass_config_path = "/tmp/opencas_ioclass.conf"
 mountpoint = "/tmp/cas1-1"
@@ -105,11 +106,11 @@ def test_ioclass_stats_sum():
         core.unmount()
         sync()
 
-        cache_stats = cache.get_statistics_deprecated(
+        cache_stats = cache.get_statistics_flat(
             stat_filter=[StatsFilter.usage, StatsFilter.req, StatsFilter.blk]
         )
         for ioclass_id in ioclass_id_list:
-            ioclass_stats = cache.get_statistics_deprecated(
+            ioclass_stats = cache.get_statistics_flat(
                 stat_filter=[StatsFilter.usage, StatsFilter.req, StatsFilter.blk],
                 io_class_id=ioclass_id,
             )


### PR DESCRIPTION
Update statistics usage to use stats classes
Rename set_statistics_deprecated to set_statistics_flat, because flat
statistics are sometimes more useful and actually not deprecated.

Signed-off-by: Daniel Madej <daniel.madej@intel.com>