### PR TITLE
Test API: Filesystem on core + set sequential cut-off fix 

### DIFF
--- a/test/functional/api/cas/casadm.py
+++ b/test/functional/api/cas/casadm.py
@@ -2,9 +2,7 @@
 # Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 #
-import csv
 
-from test_utils.output import CmdException
 from typing import List
 
 from api.cas.cache import Cache
@@ -54,7 +52,8 @@ def add_core(cache: Cache, core_dev: Device, core_id: int = None, shortcut: bool
                      core_id=_core_id, shortcut=shortcut))
     if output.exit_code != 0:
         raise CmdException("Failed to add core.", output)
-    return Core(core_dev.system_path, cache.cache_id)
+    core = Core(core_dev.system_path, cache.cache_id)
+    return core
 
 
 def remove_core(cache_id: int, core_id: int, force: bool = False, shortcut: bool = False):
@@ -252,10 +251,11 @@ def get_param_cleaning_acp(cache_id: int, output_format: OutputFormat = None,
 
 def set_param_cutoff(cache_id: int, core_id: int = None, threshold: Size = None,
                      policy: SeqCutOffPolicy = None):
-    _threshold = None if threshold is None else int(threshold.get_value(Unit.KibiByte))
+    _core_id = None if core_id is None else str(core_id)
+    _threshold = None if threshold is None else str(int(threshold.get_value(Unit.KibiByte)))
+    _policy = None if policy is None else policy.name
     command = set_param_cutoff_cmd(
-        cache_id=cache_id, core_id=core_id,
-        threshold=_threshold, policy=policy)
+        cache_id=str(cache_id), core_id=_core_id, threshold=_threshold, policy=_policy)
     output = TestRun.executor.run(command)
     if output.exit_code != 0:
         raise CmdException("Error while setting sequential cut-off params.", output)

--- a/test/functional/api/cas/core.py
+++ b/test/functional/api/cas/core.py
@@ -7,7 +7,7 @@
 from api.cas.casadm_parser import *
 from api.cas.cli import *
 from api.cas.statistics import CoreStats, CoreIoClassStats
-from test_tools import fs_utils
+from test_tools import fs_utils, disk_utils
 from test_utils.os_utils import *
 from test_utils.os_utils import wait
 
@@ -48,6 +48,10 @@ class Core(Device):
                         "core_device": split_line[2],
                         "status": split_line[3],
                         "exp_obj": split_line[5]}
+
+    def create_filesystem(self, fs_type: disk_utils.Filesystem, force=True, blocksize=None):
+        super().create_filesystem(fs_type, force, blocksize)
+        self.core_device.filesystem = self.filesystem
 
     def get_io_class_statistics(self,
                                 io_class_id: int,


### PR DESCRIPTION
Copy core device's filesystem to exported object on add
Fix set_param_cutoff function

Needs: https://github.com/Open-CAS/test-framework/pull/116

Signed-off-by: Daniel Madej <daniel.madej@intel.com>