### PR TITLE
Before stop wait for start to be finished

### DIFF
--- a/modules/cas_cache/cas_cache.h
+++ b/modules/cas_cache/cas_cache.h
@@ -58,9 +58,11 @@ struct cas_classifier;
 struct cache_priv {
 	uint64_t core_id_bitmap[DIV_ROUND_UP(OCF_CORE_MAX, 8*sizeof(uint64_t))];
 	struct cas_classifier *classifier;
+	struct work_struct start_worker;
 	struct _cache_mngt_stop_context *stop_context;
 	atomic_t flush_interrupt_enabled;
 	ocf_queue_t mngt_queue;
+	void *attach_context;
 	ocf_queue_t io_queues[];
 };
 


### PR DESCRIPTION
To prevent cache being stopped before async start finialize has finished, stop
routine have to check if worker responsible for finalizing is not running
anymore.

To create link between start finalize and stop functions, work_struct had to be
moved from attach_context to cache_priv.

Signed-off-by: Michal Mielewczyk <michal.mielewczyk@intel.com>