### PR TITLE
Improve _env_allocator_item fields alignment

### DIFF
--- a/modules/cas_cache/ocf_env.c
+++ b/modules/cas_cache/ocf_env.c
@@ -34,10 +34,10 @@ static inline size_t env_allocator_align(size_t size)
 }
 
 struct _env_allocator_item {
-	uint32_t cpu;
-	uint8_t from_rpool : 1;
-	uint8_t used : 1;
-	char data[];
+	uint32_t cpu : order_base_2(NR_CPUS);
+	uint32_t from_rpool : 1;
+	uint32_t used : 1;
+	char data[] __attribute__ ((aligned (__alignof__(uint64_t))));
 };
 
 void *env_allocator_new(env_allocator *allocator)


### PR DESCRIPTION
This change assures that data array is always optimally aligned.
Additionally item boolean flags are put into the same uint32
as cpu number in order to save space for future additions.

This change fixes ~50% performance degradation introduced by
commit d822a1d1.

Signed-off-by: Adam Rutkowski <adam.j.rutkowski@intel.com>