### PR TITLE
Introduce zero-metadata command

### DIFF
--- a/casadm/cas_lib.h
+++ b/casadm/cas_lib.h
@@ -268,6 +268,14 @@ int validate_str_output_format(const char* s);
 int validate_str_metadata_mode(const char* s);
 
 /**
+ * @brief clear metadata
+ *
+ * @param[in] cache_device device to which zeroing cache's metadata applies
+ * @return 0 if succeed, 1 if failed
+ */
+int zero_md(const char *cache_device);
+
+/**
  * @brief calculate flush progress
  *
  * @param[in] dirty number of dirty blocks


### PR DESCRIPTION
Introduce **`zero-metadata`** command for OpenCAS Linux
which clears CAS's metadata from device.

closes #360