### PR TITLE
Disable the possibility to use the 'load' and 'force' flags at once

### DIFF
--- a/casadm/cas_main.c
+++ b/casadm/cas_main.c
@@ -294,6 +294,11 @@ int handle_start()
 	int status;
 	struct stat device_info;
 
+	if (command_args_values.state == CACHE_INIT_LOAD && command_args_values.force) {
+		cas_printf(LOG_ERR, "Use of 'load' and 'force' simultaneously is forbidden.\n");
+		return FAILURE;
+	}
+
 	cache_device = open(command_args_values.cache_device, O_RDONLY);
 
 	if (cache_device < 0) {

--- a/test/functional/api/cas/cli_messages.py
+++ b/test/functional/api/cas/cli_messages.py
@@ -59,6 +59,10 @@ stop_cache_mounted_core = [
     r"Can\'t stop cache instance \d+\. Device /dev/cas\d+-\d+ is mounted\!"
 ]
 
+load_and_force = [
+    r"Use of \'load\' and \'force\' simultaneously is forbidden\."
+]
+
 
 def check_stderr_msg(output: Output, expected_messages):
     return __check_string_msg(output.stderr, expected_messages)


### PR DESCRIPTION
Discard wrong combination of flags in `--start-cache` command.
Print error message.
Add test to check the above functionality.

Closes #378