### PR TITLE
Improve installer

### DIFF
--- a/test/functional/api/cas/git.py
+++ b/test/functional/api/cas/git.py
@@ -9,10 +9,12 @@ from core.test_run import TestRun
 from connection.local_executor import LocalExecutor
 
 
-def get_current_commit_hash():
-    local_executor = LocalExecutor()
-    return local_executor.run(
-        f"cd {TestRun.usr.repo_dir} &&"
+def get_current_commit_hash(from_dut: bool = False):
+    executor = TestRun.executor if from_dut else LocalExecutor()
+    repo_path = TestRun.usr.working_dir if from_dut else TestRun.usr.repo_dir
+
+    return executor.run(
+        f"cd {repo_path} &&"
         f'git show HEAD -s --pretty=format:"%H"').stdout
 
 

--- a/test/functional/api/cas/git.py
+++ b/test/functional/api/cas/git.py
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 #
 
+import os
+
 from core.test_run import TestRun
 from connection.local_executor import LocalExecutor
 
@@ -19,3 +21,13 @@ def get_current_commit_message():
     return local_executor.run(
         f"cd {TestRun.usr.repo_dir} &&"
         f'git show HEAD -s --pretty=format:"%B"').stdout
+
+
+def get_release_tags():
+    repo_path = os.path.join(TestRun.usr.working_dir, ".git")
+    output = TestRun.executor.run_expect_success(f"git --git-dir={repo_path} tag").stdout
+
+    # Tags containing '-' or '_' are not CAS release versions
+    tags = [v for v in output.splitlines() if "-" not in v and "_" not in v]
+
+    return tags

--- a/test/functional/api/cas/installer.py
+++ b/test/functional/api/cas/installer.py
@@ -58,13 +58,13 @@ def install_opencas():
         TestRun.LOGGER.info(output.stdout)
 
 
-def set_up_opencas():
+def set_up_opencas(version=None):
     rsync_opencas_sources()
 
     _clean_opencas_repo()
 
     if version:
-        git.checkout_cas_version()
+        git.checkout_cas_version(version)
 
     build_opencas()
 
@@ -84,10 +84,10 @@ def uninstall_opencas():
             raise CmdException("There was an error during uninstall process", output)
 
 
-def reinstall_opencas():
+def reinstall_opencas(version=None):
     if check_if_installed():
         uninstall_opencas()
-    set_up_opencas()
+    set_up_opencas(version)
 
 
 def check_if_installed():

--- a/test/functional/api/cas/installer.py
+++ b/test/functional/api/cas/installer.py
@@ -59,8 +59,6 @@ def install_opencas():
 
 
 def set_up_opencas(version=None):
-    rsync_opencas_sources()
-
     _clean_opencas_repo()
 
     if version:

--- a/test/functional/api/cas/installer.py
+++ b/test/functional/api/cas/installer.py
@@ -21,6 +21,18 @@ def install_opencas():
         exclude_list=["test/functional/results/"],
         delete=True)
 
+
+def _clean_opencas_repo():
+    TestRun.LOGGER.info("Cleaning Open CAS repo")
+    output = TestRun.executor.run(
+        f"cd {TestRun.usr.working_dir} && "
+        "make distclean")
+    if output.exit_code != 0:
+        raise CmdException("make distclean command executed with nonzero status", output)
+
+
+def install_opencas():
+    _clean_opencas_repo()
     TestRun.LOGGER.info("Building Open CAS")
     output = TestRun.executor.run(
         f"cd {TestRun.usr.working_dir} && "

--- a/test/functional/api/cas/installer.py
+++ b/test/functional/api/cas/installer.py
@@ -8,12 +8,13 @@ import logging
 
 from tests import conftest
 from core.test_run import TestRun
+from api.cas import git
 from api.cas import cas_module
 from test_utils import os_utils
 from test_utils.output import CmdException
 
 
-def install_opencas():
+def rsync_opencas_sources():
     TestRun.LOGGER.info("Copying Open CAS repository to DUT")
     TestRun.executor.rsync_to(
         f"{TestRun.usr.repo_dir}/",
@@ -31,8 +32,7 @@ def _clean_opencas_repo():
         raise CmdException("make distclean command executed with nonzero status", output)
 
 
-def install_opencas():
-    _clean_opencas_repo()
+def build_opencas():
     TestRun.LOGGER.info("Building Open CAS")
     output = TestRun.executor.run(
         f"cd {TestRun.usr.working_dir} && "
@@ -41,6 +41,8 @@ def install_opencas():
     if output.exit_code != 0:
         raise CmdException("Make command executed with nonzero status", output)
 
+
+def install_opencas():
     TestRun.LOGGER.info("Installing Open CAS")
     output = TestRun.executor.run(
         f"cd {TestRun.usr.working_dir} && "
@@ -54,6 +56,19 @@ def install_opencas():
         raise CmdException("'casadm -V' command returned an error", output)
     else:
         TestRun.LOGGER.info(output.stdout)
+
+
+def set_up_opencas():
+    rsync_opencas_sources()
+
+    _clean_opencas_repo()
+
+    if version:
+        git.checkout_cas_version()
+
+    build_opencas()
+
+    install_opencas()
 
 
 def uninstall_opencas():
@@ -72,7 +87,7 @@ def uninstall_opencas():
 def reinstall_opencas():
     if check_if_installed():
         uninstall_opencas()
-    install_opencas()
+    set_up_opencas()
 
 
 def check_if_installed():

--- a/test/functional/api/cas/version.py
+++ b/test/functional/api/cas/version.py
@@ -1,0 +1,32 @@
+#
+# Copyright(c) 2019-2020 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+#
+
+import os
+
+from api.cas import git
+from packaging import version
+
+
+class CasVersion(version.Version):
+    def can_be_upgraded(self):
+        return self >= CasVersion("v20.1")
+
+    def __str__(self):
+        return f"v{super().__str__()}"
+
+    def __repr__(self):
+        return str(self)
+
+
+def get_available_cas_versions():
+    release_tags = git.get_release_tags()
+
+    versions = [CasVersion(tag) for tag in release_tags]
+
+    return versions
+
+
+def get_upgradable_cas_versions():
+    return [v for v in get_available_cas_versions() if v.can_be_upgraded()]

--- a/test/functional/tests/conftest.py
+++ b/test/functional/tests/conftest.py
@@ -172,8 +172,10 @@ def base_prepare(item):
                 raise Exception(f"Failed to remove partitions from {disk}")
 
         if get_force_param(item) and not TestRun.usr.already_updated:
+            installer.rsync_opencas_sources()
             installer.reinstall_opencas()
         elif not installer.check_if_installed():
+            installer.rsync_opencas_sources()
             installer.set_up_opencas()
         TestRun.usr.already_updated = True
         TestRun.LOGGER.add_build_info(f'Commit hash:')

--- a/test/functional/tests/conftest.py
+++ b/test/functional/tests/conftest.py
@@ -174,7 +174,7 @@ def base_prepare(item):
         if get_force_param(item) and not TestRun.usr.already_updated:
             installer.reinstall_opencas()
         elif not installer.check_if_installed():
-            installer.install_opencas()
+            installer.set_up_opencas()
         TestRun.usr.already_updated = True
         TestRun.LOGGER.add_build_info(f'Commit hash:')
         TestRun.LOGGER.add_build_info(f"{git.get_current_commit_hash()}")


### PR DESCRIPTION
Installing particular CAS version via test API will be used in upgrade-in-flight tests. 
Refactoring `test/functional/api/cas/installer.py` will allow to expand it with API for rpms