### PR TITLE
Don't check TF presence in configure

### DIFF
--- a/configure
+++ b/configure
@@ -29,7 +29,6 @@ SCRIPTPATH=`dirname $0`
 SCRIPTPATH=`realpath $SCRIPTPATH`
 SUBMODULES=(
 	"ocf"
-	"test/functional/test-framework"
 )
 
 for SUBMOD in ${SUBMODULES[@]}; do


### PR DESCRIPTION
Since test-framework isn't needed to compile CAS I suggest we remove the
check for it in configure.

Signed-off-by: Jan Musial <jan.musial@intel.com>