### PR TITLE
Fix issue of removing a core device whose core id is a subset of other core device's 

### DIFF
--- a/casadm/cas_lib.c
+++ b/casadm/cas_lib.c
@@ -1811,7 +1811,7 @@ int check_if_mounted(int cache_id, int core_id)
 	FILE *mtab;
 	struct mntent *mstruct;
 	char dev_buf[80];
-	int dev_buf_len;
+	int dev_buf_len, mnt_fsname_len;
 	if (0 <= core_id) {
 		/* verify if specific core is mounted */
 		snprintf(dev_buf, sizeof(dev_buf), "/dev/cas%d-%d", cache_id, core_id);
@@ -1829,9 +1829,11 @@ int check_if_mounted(int cache_id, int core_id)
 	}
 
 	while ((mstruct = getmntent(mtab)) != NULL) {
+		mnt_fsname_len = strnlen(mstruct->mnt_fsname,
+				(sizeof("/dev/") + sizeof(mstruct->mnt_fsname)));
 		/* mstruct->mnt_fsname is /dev/... block device path, not a mountpoint */
 		if ((NULL != mstruct->mnt_fsname)
-		    && (strncmp(mstruct->mnt_fsname, dev_buf, dev_buf_len) == 0)) {
+		    && (strncmp(mstruct->mnt_fsname, dev_buf, max(dev_buf_len, mnt_fsname_len)) == 0)) {
 			if (core_id<0) {
 				cas_printf(LOG_ERR,
 					   "Can't stop cache instance %d. Device %s is mounted!\n",

--- a/casadm/ocf_env.h
+++ b/casadm/ocf_env.h
@@ -11,6 +11,7 @@
 #include "safeclib/safe_lib.h"
 
 #define min(x, y)  ({ x < y ? x : y; })
+#define max(x, y)  ({ x > y ? x : y; })
 
 #define ENV_BUG_ON(cond) ({ if (cond) exit(1); })
 


### PR DESCRIPTION
Here is the exact issue this patch fixes. 

[root@localhost ~]# casadm -L
type    id   disk              status    write policy   device
cache   1    /dev/nvme10n1p1   Running   wt             -
├core   1    /dev/nvme1n1      Active    -              /dev/cas1-1
└core   10   /dev/nvme2n1      Active    -              /dev/cas1-10
[root@localhost ~]# 
[root@localhost ~]# cat /etc/mtab | grep cas
/dev/cas1-10 /mnt/disk1 xfs rw,seclabel,relatime,attr2,inode64,noquota 0 0
[root@localhost ~]# 
[root@localhost ~]# casadm -R -i 1 -j 1
Can't remove core 1 from cache 1. Device /dev/cas1-10 is mounted!