### PR TITLE
tests: Fix CAS version parsing

### DIFF
--- a/test/functional/api/cas/casadm_parser.py
+++ b/test/functional/api/cas/casadm_parser.py
@@ -12,10 +12,9 @@ from test_utils.size import parse_unit
 from storage_devices.device import Device
 from api.cas.cache_config import *
 from api.cas.casadm_params import *
+from api.cas.version import CasVersion
 from datetime import timedelta
 from typing import List
-
-from packaging import version
 
 from api.cas import casadm
 from api.cas.cache_config import *
@@ -275,4 +274,4 @@ def get_seq_cut_off_parameters(cache_id: int, core_id: int):
 def get_casadm_version():
     casadm_output = casadm.print_version(OutputFormat.csv).stdout.split('\n')
     version_str = casadm_output[1].split(',')[-1]
-    return version.parse(version_str)
+    return CasVersion.from_version_string(version_str)

--- a/test/functional/api/cas/init_config.py
+++ b/test/functional/api/cas/init_config.py
@@ -55,8 +55,7 @@ class InitConfig:
     @classmethod
     def create_default_init_config(cls):
         cas_version = casadm_parser.get_casadm_version()
-        fs_utils.write_file(opencas_conf_path,
-                            f"version={'.'.join(str(x) for x in cas_version.release[0:3])}")
+        fs_utils.write_file(opencas_conf_path, f"version={cas_version.base}")
 
 
 class CacheConfigLine:

--- a/test/functional/api/cas/version.py
+++ b/test/functional/api/cas/version.py
@@ -3,27 +3,46 @@
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 #
 
-import os
+import re
 
 from api.cas import git
-from packaging import version
 
 
-class CasVersion(version.Version):
+class CasVersion:
+    def __init__(self, main, major, minor, pr, release_type):
+        self.main = main
+        self.major = major
+        self.minor = minor
+        self.pr = pr
+        self.type = release_type
+        self.base = f"{self.main}.{self.major}.{self.minor}"
+
     def can_be_upgraded(self):
-        return self >= CasVersion("v20.1")
+        return self.main >= 20
 
     def __str__(self):
-        return f"v{super().__str__()}"
+        return f"{self.main}.{self.major}.{self.minor}.{self.pr}.{self.type}"
 
     def __repr__(self):
         return str(self)
+
+    @classmethod
+    def from_git_tag(cls, version_tag):
+        m = re.fullmatch(r'v([0-9]+)\.([0-9]+)\.?([0-9]?)', "v20.3")
+        main, major, minor = m.groups()
+        if not minor:
+            minor = '0'
+        return cls(main, major, minor, 0, "master")
+
+    @classmethod
+    def from_version_string(cls, version_string):
+        return cls(*version_string.split('.'))
 
 
 def get_available_cas_versions():
     release_tags = git.get_release_tags()
 
-    versions = [CasVersion(tag) for tag in release_tags]
+    versions = [CasVersion.from_git_tag(tag) for tag in release_tags]
 
     return versions
 


### PR DESCRIPTION
As CAS version format changed to custom one, we need to parse it
in non-default way.

Signed-off-by: Robert Baldyga <robert.baldyga@intel.com>