### PR TITLE
Swap formatting NVMe to metadata zeroing in functional tests CAS API

### DIFF
--- a/test/functional/api/cas/casadm.py
+++ b/test/functional/api/cas/casadm.py
@@ -140,11 +140,11 @@ def print_version(output_format: OutputFormat = None, shortcut: bool = False):
     return output
 
 
-def format_nvme(cache_dev: Device, force: bool = False, shortcut: bool = False):
+def zero_metadata(cache_dev: Device, shortcut: bool = False):
     output = TestRun.executor.run(
-        format_cmd(cache_dev=cache_dev.system_path, force=force, shortcut=shortcut))
+        zero_metadata_cmd(cache_dev=cache_dev.system_path, shortcut=shortcut))
     if output.exit_code != 0:
-        raise CmdException("Format command failed.", output)
+        raise CmdException("Failed to wipe metadata.", output)
     return output
 
 

--- a/test/functional/api/cas/cli.py
+++ b/test/functional/api/cas/cli.py
@@ -104,10 +104,9 @@ def print_statistics_cmd(cache_id: str, core_id: str = None, per_io_class: bool 
     return casadm_bin + command
 
 
-def format_cmd(cache_dev: str, force: bool = False, shortcut: bool = False):
-    command = (" -N -F -d " if shortcut else " --nvme --format --device ") + cache_dev
-    if force:
-        command += " -f" if shortcut else " --force"
+def zero_metadata_cmd(cache_dev: str, shortcut: bool):
+    command = " --zero-metadata"
+    command += (" -d " if shortcut else " --device ") + cache_dev
     return casadm_bin + command
 
 


### PR DESCRIPTION
Remove formatting NVMe from test's API
Add metadata zeroing to test's API

Can wait for NVMe formatting to be removed from OCL, but it's used nowhere by now.
New command could be tested.

Signed-off-by: Slawomir Jankowski <slawomir.jankowski@intel.com>