### PR TITLE
Fix message when CAS can't open exclusively inactive core

### DIFF
--- a/casadm/cas_lib.c
+++ b/casadm/cas_lib.c
@@ -1408,7 +1408,7 @@ int check_core_already_cached(const char *core_device) {
 		curr_cache = caches[i];
 		for (j = 0; j < curr_cache->core_count; ++j) {
 			curr_core = &curr_cache->cores[j];
-			if (0 ==
+			if (curr_core->info.state == ocf_core_state_active && 0 ==
 			strncmp(core_device_path, curr_core->path, MAX_STR_LEN)) {
 				free_cache_devices_list(caches, caches_count);
 				return FAILURE;


### PR DESCRIPTION
Fix for bug with reporting reason why we can't open core device. Whenever we had an inactive core, which was opened by some other process we'd report it as being already cached - because we'd check only its presence in core list of any cache, not the state.

Signed-off-by: Jan Musial <jan.musial@intel.com>