### PR TITLE
configure: add CAS_BLK_BIDI_RQ() macro

### DIFF
--- a/configure.d/1_blk_bidi_req.conf
+++ b/configure.d/1_blk_bidi_req.conf
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# Copyright(c) 2012-2020 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+#
+
+. $(dirname $3)/conf_framework
+
+check() {
+    cur_name=$(basename $2)
+    config_file_path=$1
+    if compile_module $cur_name "blk_bidi_rq(rq);" "linux/blkdev.h"
+    then
+        echo $cur_name "1" >> $config_file_path
+    else
+        echo $cur_name "2" >> $config_file_path
+    fi
+}
+
+apply() {
+    case "$1" in
+    "1")
+        add_define "CAS_BLK_BIDI_RQ(rq) \\
+            blk_bidi_rq(rq)" ;;
+    "2")
+        add_define "CAS_BLK_BIDI_RQ(rq) \\
+            false" ;;
+    *)
+        exit 1
+    esac
+}
+
+conf_run $@

--- a/modules/cas_cache/volume/vol_block_dev_top.c
+++ b/modules/cas_cache/volume/vol_block_dev_top.c
@@ -22,10 +22,8 @@ static inline bool _blockdev_can_handle_rq(struct request *rq)
 	if (unlikely(!cas_is_rq_type_fs(rq)))
 		error = __LINE__;
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 1, 0)
-	if (unlikely(blk_bidi_rq(rq)))
+	if (unlikely(CAS_BLK_BIDI_RQ(rq)))
 		error = __LINE__;
-#endif
 
 	if (error != 0) {
 		CAS_PRINT_RL(KERN_ERR "%s cannot handle request (ERROR %d)\n",


### PR DESCRIPTION
Since commit 8b3238cabd50e27 in linux kernel removed blk_bidi_rq() marco, it
has to be wrapped in CAS `configure` script.

Signed-off-by: Michal Mielewczyk <michal.mielewczyk@intel.com>