### PR TITLE
Remove potentially_dirty counter from bottom volume

### DIFF
--- a/modules/cas_cache/volume/obj_blk.h
+++ b/modules/cas_cache/volume/obj_blk.h
@@ -14,18 +14,8 @@ struct casdsk_disk;
 
 struct bd_object {
 	struct casdsk_disk *dsk;
+
 	struct block_device *btm_bd;
-	/**
-	 * This denotes state of volatile write cache of the device.
-	 * This is set to true when:
-	 *  - opening the device
-	 *  - when writing to a device without FUA/FLUSH flags
-	 * This is set to false when:
-	 *  - FLUSH request is completed on device.
-	 * When it is false
-	 *  - FLUSH requests from upper layer are NOT passed to the device.
-	 */
-	atomic_t potentially_dirty;
 
 	uint32_t expobj_valid : 1;
 		/*!< Bit indicates that exported object was created */

--- a/modules/cas_cache/volume/vol_blk_utils.h
+++ b/modules/cas_cache/volume/vol_blk_utils.h
@@ -24,7 +24,6 @@ struct blkio {
 	int error;
 	atomic_t rq_remaning;
 	atomic_t ref_counter;
-	int32_t dirty;
 	int32_t dir;
 
 	struct blk_data *data; /* IO data buffer */


### PR DESCRIPTION
This counter is not accurate (missing required memory barrier
to avoid unwanted behavior due to processor optimizations)
and performance gain is not clear - generally global
atomic variables are something we would like to avoid
going forward.

Signed-off-by: Adam Rutkowski <adam.j.rutkowski@intel.com>