### PR TITLE
Blacklist /dev/disk/by-id/md-name* symlinks

### DIFF
--- a/casadm/cas_lib.c
+++ b/casadm/cas_lib.c
@@ -1627,7 +1627,7 @@ int illegal_recursive_core(unsigned int cache_id, const char *core_device, int c
 */
 static bool dev_link_blacklisted(const char* entry)
 {
-	static const char* const prefix_blacklist[] = {"lvm"};
+	static const char* const prefix_blacklist[] = {"lvm", "md-name"};
 	static const unsigned count = ARRAY_SIZE(prefix_blacklist);
 	const char* curr;
 	unsigned i;


### PR DESCRIPTION
This fixes startup bug when core was added to core pool by md-name*
symlink, but cache metadata contained md-uuid* path, which led to
incomplete configuration

Signed-off-by: Robert Baldyga <robert.baldyga@intel.com>