### PR TITLE
Prevent CAS settling when adding core/starting cache fails

### DIFF
--- a/utils/casctl
+++ b/utils/casctl
@@ -108,10 +108,13 @@ def init(force):
 def settle(timeout, interval):
     try:
         not_initialized = opencas.wait_for_startup(timeout, interval)
-    except Exception as e:
+    except FileNotFoundError as e:
         eprint(e)
         # Don't fail the boot if we're missing the config
         exit(0)
+    except Exception as e:
+        eprint(e)
+        exit(1)
 
     fail = False
     if not_initialized:

--- a/utils/opencas.py
+++ b/utils/opencas.py
@@ -455,7 +455,7 @@ class cas_config(object):
         except ValueError:
             raise
         except IOError:
-            raise Exception('Couldn\'t open config file')
+            raise FileNotFoundError('Couldn\'t open config file')
         except:
             raise
 
@@ -825,19 +825,19 @@ def _get_uninitialized_devices(target_dev_state):
 def wait_for_startup(timeout=300, interval=5):
     def start_device(dev):
         if os.path.exists(dev.device):
-            if type(dev) is cas_config.core_config:
-                add_core(dev, True)
-            elif type(dev) is cas_config.cache_config:
-                start_cache(dev, True)
+            try:
+                if type(dev) is cas_config.core_config:
+                    add_core(dev, True)
+                elif type(dev) is cas_config.cache_config:
+                    start_cache(dev, True)
+            except casadm.CasadmError:
+                pass
 
     stop_time = time.time() + int(timeout)
 
-    try:
-        config = cas_config.from_file(
-            cas_config.default_location, allow_incomplete=True
-        )
-    except Exception as e:
-        raise Exception("Unable to load opencas config. Reason: {0}".format(str(e)))
+    config = cas_config.from_file(
+        cas_config.default_location, allow_incomplete=True
+    )
 
     not_initialized = _get_uninitialized_devices(config)
     if not not_initialized:


### PR DESCRIPTION
Fix situation where adding core/starting cache would throw an exception and cause `casctl settle` to simply quit waiting.

* Exceptions thrown when config file is missing are now more sane
* Only missing config file when settling is tolerated, all other exceptions make `casctl settle` fail

Signed-off-by: Jan Musial <jan.musial@intel.com>