### PR TITLE
Specify modules source dir to avoid build warnings

### DIFF
--- a/configure.d/conf_framework
+++ b/configure.d/conf_framework
@@ -7,7 +7,7 @@
 SCRIPTPATH=`dirname $0`
 SCRIPTPATH=`realpath $SCRIPTPATH`
 KERNEL_DIR="${KERNEL_DIR:-/lib/modules/$(uname -r)/build/}"
-KERNEL_VER="$(cd $KERNEL_DIR; make kernelversion)"
+KERNEL_VER="$(cd $KERNEL_DIR; make M=$SCRIPTPATH kernelversion)"
 NPROC=`nproc`
 DEFINE_FILE=$SCRIPTPATH/modules/generated_defines.h
 


### PR DESCRIPTION
If we run 'make kernelversion' in a read-only dir then it produces

  mkdir: cannot create directory ‘.tmp_1056416’: Permission denied
  mkdir: cannot create directory ‘.tmp_1056420’: Permission denied
  mkdir: cannot create directory ‘.tmp_1056421’: Permission denied
  mkdir: cannot create directory ‘.tmp_1056423’: Permission denied

warnings. To avoid it we need to specify where the source (and build)
directory located.

Closes #540

Signed-off-by: Anatol Pomozov <anatol.pomozov@gmail.com>