### PR TITLE
configure: only check for kernel headers when no kernel source

### DIFF
--- a/configure
+++ b/configure
@@ -42,7 +42,7 @@ if [ "$SUBMODULES_MISSING" ]; then
 	MISSING_TOOLS=1
 fi
 
-if [ ! -e /lib/modules/$(uname -r)/build/ &> /dev/null ]
+if [ ! -e /lib/modules/$(uname -r)/build/ &> /dev/null ] && [ "$KERNEL_DIR" == "" ]
 then
 	echo >&2 "Error: missing kernel headers and/or kernel devel"
 	MISSING_TOOLS=1


### PR DESCRIPTION
configure should not fail if kernel devel package is missing
when user is calling configure with explicit path to kernel source
(specified via KELRNEL_DIR environment variable).

Signed-off-by: Adam Rutkowski <adam.j.rutkowski@intel.com>