### PR TITLE
utils: Exclude Open CAS modules from dracut initramfs image

### DIFF
--- a/utils/Makefile
+++ b/utils/Makefile
@@ -35,6 +35,9 @@ install_files:
 	@install -m 755 casctl $(DESTDIR)$(CASCTL_DIR)/casctl
 	@install -m 755 open-cas-loader $(DESTDIR)$(CASCTL_DIR)/open-cas-loader
 
+	@mkdir -p $(DESTDIR)/etc/dracut.conf.d/
+	@install -m 644 etc/dracut.conf.d/opencas.conf $(DESTDIR)/etc/dracut.conf.d/opencas.conf
+
 	@mkdir -p $(DESTDIR)/sbin
 	@ln -fs $(CASCTL_DIR)/casctl $(DESTDIR)/sbin/casctl
 
@@ -59,6 +62,8 @@ uninstall:
 	@rm $(DESTDIR)$(CASCTL_DIR)/casctl
 	@rm $(DESTDIR)$(CASCTL_DIR)/open-cas-loader
 	@rm -rf $(DESTDIR)$(CASCTL_DIR)
+
+	@rm $(DESTDIR)/etc/dracut.conf.d/opencas.conf
 
 	@rm $(DESTDIR)/sbin/casctl
 

--- a/utils/etc/dracut.conf.d/opencas.conf
+++ b/utils/etc/dracut.conf.d/opencas.conf
@@ -1,0 +1,1 @@
+omit_drivers+=" cas_disk cas_cache"

--- a/utils/pckgen.d/rpm/CAS_NAME.spec
+++ b/utils/pckgen.d/rpm/CAS_NAME.spec
@@ -108,6 +108,7 @@ fi
 %dir /var/lib/opencas
 %config /etc/opencas/opencas.conf
 /etc/opencas/ioclass-config.csv
+/etc/dracut.conf.d/opencas.conf
 /var/lib/opencas/cas_version
 /lib/opencas/casctl
 /lib/opencas/open-cas-loader


### PR DESCRIPTION
Open CAS modules are not intended to be included into initramfs, and so
CAS upgrade does not trigger initramfs rebuild. This may lead to loading
old Open CAS modules if they were included into initramfs image. Explicitly
excluding them from initramfs image effectively addressed this issue.

Signed-off-by: Robert Baldyga <robert.baldyga@intel.com>