### PR TITLE
Change required cache device type for test checking discards at cache start

### DIFF
--- a/test/functional/tests/io/trim/test_trim.py
+++ b/test/functional/tests/io/trim/test_trim.py
@@ -19,7 +19,7 @@ from test_tools.fio.fio_param import ReadWrite, IoEngine
 from storage_devices.disk import DiskType, DiskTypeSet
 
 
-@pytest.mark.require_disk("cache", DiskTypeSet([DiskType.optane, DiskType.nand]))
+@pytest.mark.require_disk("cache", DiskTypeSet([DiskType.nand]))
 def test_trim_start_discard():
     """
     title: Check discarding cache device at cache start


### PR DESCRIPTION
This change was made due to the fact, that optane device is not discarded at the cache start

Signed-off-by: Katarzyna Lapinska <katarzyna.lapinska@intel.com>