### PR TITLE
fix for removing partitions after mdadm --zero-superblock command

### DIFF
--- a/test/functional/tests/conftest.py
+++ b/test/functional/tests/conftest.py
@@ -197,6 +197,7 @@ def base_prepare(item):
         for disk in TestRun.dut.disks:
             disk.umount_all_partitions()
             Mdadm.zero_superblock(disk.system_path)
+            TestRun.executor.run_expect_success("udevadm settle")
             disk.remove_partitions()
             create_partition_table(disk, PartitionTable.gpt)
 


### PR DESCRIPTION
fix for removing partitions after mdadm --zero-superblock command

Signed-off-by: Karolina Rogowska <karolina.rogowska@intel.com>