### PR TITLE
casadm: prevent acccess to uninitialized variables

### DIFF
--- a/casadm/cas_lib.c
+++ b/casadm/cas_lib.c
@@ -2842,7 +2842,7 @@ int _check_cache_device(const char *device_path,
 
 int check_cache_device(const char *device_path)
 {
-	struct kcas_cache_check_device cmd_info;
+	struct kcas_cache_check_device cmd_info = {};
 	FILE *intermediate_file[2];
 	int result;
 
@@ -2878,9 +2878,10 @@ int check_cache_device(const char *device_path)
 }
 
 int zero_md(const char *cache_device){
-	struct kcas_cache_check_device cmd_info;
+	struct kcas_cache_check_device cmd_info = {};
 	char zero_page[4096] = {0};
 	int fd = 0;
+	int result;
 
 	/* check if given cache device exists */
 	fd = open(cache_device, O_RDONLY);
@@ -2897,8 +2898,13 @@ int zero_md(const char *cache_device){
 		return FAILURE;
 	}
 
+	result = _check_cache_device(cache_device, &cmd_info);
+	if (result == FAILURE) {
+		cas_printf(LOG_ERR, "Failed to retrieve device's information.\n");
+		return FAILURE;
+	}
+
 	/* don't delete metadata if device hasn't got CAS's metadata */
-	_check_cache_device(cache_device, &cmd_info);
 	if (!cmd_info.is_cache_device) {
 		cas_printf(LOG_ERR, "Device '%s' does not contain OpenCAS's metadata.\n", cache_device);
 		return FAILURE;


### PR DESCRIPTION
Signed-off-by: Michal Mielewczyk <michal.mielewczyk@intel.com>