### PR TITLE
Fix few issues from security review

### DIFF
--- a/casadm/cas_lib.c
+++ b/casadm/cas_lib.c
@@ -540,11 +540,9 @@ const char *get_core_state_name(int core_state)
 /* check if device is atomic and print information about potential slow start */
 void print_slow_atomic_cache_start_info(const char *device_path)
 {
-	char buff[MAX_STR_LEN];
 	struct kcas_cache_check_device cmd_info;
 	int ret;
 
-	get_dev_path(device_path, buff, sizeof(buff));
 	ret = _check_cache_device(device_path, &cmd_info);
 
 	if (!ret && cmd_info.format_atomic) {

--- a/casadm/cas_lib.c
+++ b/casadm/cas_lib.c
@@ -630,6 +630,7 @@ static bool is_dev_link_whitelisted(const char* path)
 	return false;
 }
 
+/* Call this only AFTER normalizing path */
 static int _is_by_id_path(const char* dev_path)
 {
 	static const char dev_by_id_dir[] = "/dev/disk/by-id";

--- a/casadm/cas_lib.c
+++ b/casadm/cas_lib.c
@@ -653,8 +653,7 @@ int set_device_path(char *dest_path, size_t dest_len, const char *src_path, size
 
 	/* check if given dev_path is whitelisted and then pass it as path or not */
 	if (is_dev_link_whitelisted(abs_dev_path)){
-		result = strncpy_s(dest_path, dest_len, abs_dev_path,
-		    strnlen_s(abs_dev_path, sizeof(abs_dev_path)));
+		result = strncpy_s(dest_path, dest_len, abs_dev_path, sizeof(abs_dev_path));
 		return result ?: SUCCESS;
 	}
 

--- a/casadm/cas_lib.c
+++ b/casadm/cas_lib.c
@@ -819,11 +819,8 @@ struct cache_device *get_cache_device(const struct kcas_cache_info *info, bool b
 	cache->expected_core_count = info->info.core_count;
 	cache->id = cache_id;
 	cache->state = info->info.state;
-	if (set_device_path(cache->device, sizeof(cache->device), info->cache_path_name,
-			    sizeof(info->cache_path_name)) != SUCCESS) {
-		free(cache);
-		return NULL;
-	}
+	strncpy_s(cache->device, sizeof(cache->device), info->cache_path_name,
+		  strnlen_s(info->cache_path_name, sizeof(info->cache_path_name)));
 	cache->mode = info->info.cache_mode;
 	cache->dirty = info->info.dirty;
 	cache->flushed = info->info.flushed;
@@ -2752,8 +2749,11 @@ int list_caches(unsigned int list_format, bool by_id_path)
 		float core_flush_prog;
 
 		if (!by_id_path) {
-			get_dev_path(curr_cache->device, curr_cache->device,
-				     sizeof(curr_cache->device));
+			if (get_dev_path(curr_cache->device, curr_cache->device,
+				     sizeof(curr_cache->device))) {
+				cas_printf(LOG_WARNING, "WARNING: Cannot resolve path "
+					   "to cache. By-id path will be shown for that cache.\n");
+			}
 		}
 
 		cache_flush_prog = calculate_flush_progress(curr_cache->dirty, curr_cache->flushed);


### PR DESCRIPTION
Change strnlen to sizeof in set_device_path()
Fix casadm's handling of listing caches for caches added outside casadm.
Remove unused `buff` from `print_slow_atomic_cache_start_info()`
Add comment about calling only after normalizing path

Signed-off-by: Slawomir Jankowski <slawomir.jankowski@intel.com>