### PR TITLE
Restore more conservative free memory calculation method

### DIFF
--- a/configure.d/1_global_page_state.conf
+++ b/configure.d/1_global_page_state.conf
@@ -9,39 +9,30 @@
 check() {
 	cur_name=$(basename $2)
 	config_file_path=$1
-	if compile_module $cur_name "si_mem_available()" "linux/mm.h"
+	if compile_module $cur_name "global_zone_page_state(1)" "linux/mm.h"
 	then
 		echo $cur_name "1" >> $config_file_path
-
-	elif compile_module $cur_name "global_zone_page_state(1)" "linux/mm.h"
-	then
-		echo $cur_name "2" >> $config_file_path
 	elif compile_module $cur_name "global_page_state(1)" "linux/mm.h"
 	then
-		echo $cur_name "3" >> $config_file_path
-	else
-	    echo $cur_name "X" >> $config_file_path
-	fi
+		echo $cur_name "2" >> $config_file_path
+    else
+        echo $cur_name "X" >> $config_file_path
+    fi
 }
 
 apply() {
     case "$1" in
     "1")
 		add_function "
-	static inline unsigned long cas_get_free_mem(void)
-		{	return si_mem_available() << PAGE_SHIFT;
+	static inline unsigned long cas_global_zone_page_state(enum zone_stat_item item)
+		{
+			return global_zone_page_state(item);
 		}" ;;
     "2")
 		add_function "
-	static inline unsigned long cas_get_free_mem(void)
+	static inline unsigned long cas_global_zone_page_state(enum zone_stat_item item)
 		{
-			return global_zone_page_state(NR_FREE_PAGES) << PAGE_SHIFT;
-		}" ;;
-    "3")
-		add_function "
-	static inline unsigned long cas_get_free_mem(void)
-		{
-			return global_page_state(NR_FREE_PAGES) << PAGE_SHIFT;
+			return global_page_state(item);
 		}" ;;
     *)
         exit 1

--- a/configure.d/1_global_page_state.conf
+++ b/configure.d/1_global_page_state.conf
@@ -7,14 +7,14 @@
 . $(dirname $3)/conf_framework
 
 check() {
-	cur_name=$(basename $2)
-	config_file_path=$1
-	if compile_module $cur_name "global_zone_page_state(1)" "linux/mm.h"
-	then
-		echo $cur_name "1" >> $config_file_path
-	elif compile_module $cur_name "global_page_state(1)" "linux/mm.h"
-	then
-		echo $cur_name "2" >> $config_file_path
+    cur_name=$(basename $2)
+    config_file_path=$1
+    if compile_module $cur_name "global_zone_page_state(1)" "linux/mm.h"
+    then
+        echo $cur_name "1" >> $config_file_path
+    elif compile_module $cur_name "global_page_state(1)" "linux/mm.h"
+    then
+        echo $cur_name "2" >> $config_file_path
     else
         echo $cur_name "X" >> $config_file_path
     fi
@@ -23,17 +23,17 @@ check() {
 apply() {
     case "$1" in
     "1")
-		add_function "
-	static inline unsigned long cas_global_zone_page_state(enum zone_stat_item item)
-		{
-			return global_zone_page_state(item);
-		}" ;;
+        add_function "
+        static inline unsigned long cas_global_zone_page_state(enum zone_stat_item item)
+        {
+            return global_zone_page_state(item);
+        }" ;;
     "2")
-		add_function "
-	static inline unsigned long cas_global_zone_page_state(enum zone_stat_item item)
-		{
-			return global_page_state(item);
-		}" ;;
+        add_function "
+        static inline unsigned long cas_global_zone_page_state(enum zone_stat_item item)
+        {
+            return global_page_state(item);
+        }" ;;
     *)
         exit 1
     esac

--- a/modules/cas_cache/ocf_env.h
+++ b/modules/cas_cache/ocf_env.h
@@ -21,7 +21,7 @@
 
 static inline uint64_t env_get_free_memory(void)
 {
-	return cas_get_free_mem();
+	return cas_global_zone_page_state(NR_FREE_PAGES) << PAGE_SHIFT;
 }
 
 static inline void *env_malloc(size_t size, int flags)


### PR DESCRIPTION
This method produced too optimistic free memory value, which in result led to oom killer activation.
This patch restores more conservative free memory calculation method.

This reverts commit 1e9b7a4262327b9519653bd3700141d054a2f438.

Fixes #630 