### PR TITLE
Zero metadata if on-disk version differs from current

### DIFF
--- a/casadm/cas_lib.c
+++ b/casadm/cas_lib.c
@@ -2894,7 +2894,7 @@ int check_cache_device(const char *device_path)
 	fprintf(intermediate_file[1], TAG(TABLE_HEADER) "Is cache,Clean Shutdown,Cache dirty\n");
 
 	fprintf(intermediate_file[1], TAG(TABLE_ROW));
-	if (cmd_info.is_cache_device) {
+	if (cmd_info.is_cache_device && cmd_info.metadata_compatible) {
 		fprintf(intermediate_file[1], "yes,%s,%s\n",
 				cmd_info.clean_shutdown ? "yes" : "no",
 				cmd_info.cache_dirty ? "yes" : "no");

--- a/casadm/cas_lib.c
+++ b/casadm/cas_lib.c
@@ -2909,7 +2909,8 @@ int check_cache_device(const char *device_path)
 	return SUCCESS;
 }
 
-int zero_md(const char *cache_device){
+int zero_md(const char *cache_device, bool force)
+{
 	struct kcas_cache_check_device cmd_info = {};
 	char zero_page[4096] = {0};
 	int fd = 0;
@@ -2935,6 +2936,37 @@ int zero_md(const char *cache_device){
 	if (!cmd_info.is_cache_device) {
 		cas_printf(LOG_ERR, "Device '%s' does not contain OpenCAS's metadata.\n", cache_device);
 		return FAILURE;
+	}
+
+	if (!cmd_info.metadata_compatible) {
+		if (!force) {
+			cas_printf(LOG_ERR, "Unable to determine whether cache contains dirty data due to metadata mismatch.\n"
+				"Clearing metadata might result in loss of dirty data. In order to inspect cache content\n"
+				"please load cache instance using matching OpenCAS version. Alternatively, if you wish to clear\n"
+				"metadata anyway, please use '--force' option.\n");
+			return FAILURE;
+		} else {
+			cas_printf(LOG_WARNING, "Clearing metadata with unknown version - potential loss of dirty data.\n");
+		}
+	} else if (!cmd_info.clean_shutdown) {
+		if (!force) {
+			cas_printf(LOG_ERR, "Cache instance did not shut down cleanly. It might contain dirty data. \n"
+					"Clearing metadata might result in loss of dirty data. Please recover cache instance\n"
+					"by loading it and flush dirty data in order to preserve then on the core device.\n"
+					"Alternatively, if you wish to clear metadata anyway, please use '--force' option. \n");
+			return FAILURE;
+		} else {
+			cas_printf(LOG_WARNING, "Clearing metadata after dirty shutdown - potential loss of dirty data.\n");
+		}
+	} else if (cmd_info.cache_dirty) {
+		if (!force) {
+			cas_printf(LOG_ERR, "Cache instance contains dirty data. Clearing metadata will result in loss of dirty data.\n"
+					"Please load cache instance and flush dirty data in order to preserve them on the core device.\n"
+					"Alternatively, if you wish to clear metadata anyway, please use '--force' option. \n");
+			return FAILURE;
+		} else {
+			cas_printf(LOG_WARNING, "Clearing metadata for dirty pages - dirty cache data is being discarded. \n");
+		}
 	}
 
 	fd = open(cache_device, O_WRONLY | O_SYNC | O_EXCL);

--- a/casadm/cas_lib.h
+++ b/casadm/cas_lib.h
@@ -266,9 +266,11 @@ int validate_str_metadata_mode(const char* s);
  * @brief clear metadata
  *
  * @param[in] cache_device device to which zeroing cache's metadata applies
+ * @param[in] force enforce metadata erasure despite dirty data, metadata
+ * 		mistmatch and/or dirty shutdown
  * @return 0 if succeed, 1 if failed
  */
-int zero_md(const char *cache_device);
+int zero_md(const char *cache_device, bool force);
 
 /**
  * @brief calculate flush progress

--- a/casadm/cas_main.c
+++ b/casadm/cas_main.c
@@ -1832,12 +1832,15 @@ static int handle_help();
 
 struct {
 	const char *device;
+	bool force;
 } static zero_params = {
-	.device = ""
+	.device = "",
+	.force = false
 };
 
 static cli_option zero_options[] = {
 	{'d', "device", "Path to device on which metadata would be cleared", 1, "DEVICE", CLI_OPTION_REQUIRED},
+	{'f', "force", "Ignore potential dirty data on cache device"},
 	{0}
 };
 
@@ -1848,7 +1851,8 @@ int zero_handle_option(char *opt, const char **arg)
 		if(validate_device_name(arg[0]) == FAILURE)
 			return FAILURE;
 		zero_params.device = arg[0];
-
+	} else if (!strcmp(opt, "force")){
+		zero_params.force = 1;
 	} else {
 		return FAILURE;
 	}
@@ -1872,7 +1876,7 @@ int handle_zero()
 		return FAILURE;
 	}
 
-	return zero_md(zero_params.device);
+	return zero_md(zero_params.device, zero_params.force);
 }
 
 static cli_command cas_commands[] = {

--- a/modules/cas_cache/layer_cache_management.c
+++ b/modules/cas_cache/layer_cache_management.c
@@ -1012,11 +1012,17 @@ static void cache_mngt_metadata_probe_end(void *priv, int error,
 
 	*context->result = error;
 
-	if (error == -OCF_ERR_NO_METADATA || error == -OCF_ERR_METADATA_VER) {
+	if (error == -OCF_ERR_NO_METADATA) {
 		cmd_info->is_cache_device = false;
+		cmd_info->metadata_compatible = false;
+		*context->result = 0;
+	} else if (error == -OCF_ERR_METADATA_VER) {
+		cmd_info->is_cache_device = true;
+		cmd_info->metadata_compatible = false;
 		*context->result = 0;
 	} else if (error == 0) {
 		cmd_info->is_cache_device = true;
+		cmd_info->metadata_compatible = true;
 		cmd_info->clean_shutdown = status->clean_shutdown;
 		cmd_info->cache_dirty = status->cache_dirty;
 	}

--- a/modules/include/cas_ioctl_codes.h
+++ b/modules/include/cas_ioctl_codes.h
@@ -314,7 +314,12 @@ struct kcas_core_pool_remove {
 
 struct kcas_cache_check_device {
 	char path_name[MAX_STR_LEN]; /**< path to a device */
-	bool is_cache_device;
+	bool is_cache_device; /* OCF metadata detected */
+
+	/* following bool flags are defined is_cache_device == 1 */
+	bool metadata_compatible; /* OCF metadata is in current version */
+
+	/* following bool flags are defined iff is_metadata_compatible == 1 */
 	bool clean_shutdown;
 	bool cache_dirty;
 	bool format_atomic;

--- a/utils/casadm.8
+++ b/utils/casadm.8
@@ -155,6 +155,10 @@ uses 520 bytes LBA allowing to write cache data and metadata in a single
 request (atomically).
 
 .TP
+.B --zero-metadata
+Remove metadata from previously used cache device.
+
+.TP
 .B -H, --help
 Print help.
 
@@ -585,6 +589,15 @@ Identifier of cache instance <1-16384>.
 .B -o --output-format {table|csv}
 Defines output format for printed IO class configuration. It can be either
 \fBtable\fR (default) or \fBcsv\fR.
+
+.SH Options that are valid with --zero-metadata are:
+.TP
+.B -d, --device <DEVICE>
+Path to block device containing Open CAS metadata.
+
+.TP
+.B -f, --force
+Ignore potential dirty data on cache device.
 
 .SH Command --help (-H) does not accept any options.
 .BR


### PR DESCRIPTION
Kernel adapter now returns is_cache_device=1 and newly added
metadata_compatible=0 in case of metadata detected with
differing version (instead of is_cache_device = 0).

This allows zero-superblock command to recognize old
cache instance and clear it.

casadm --script --check-cache-device still returns 'Is cache'='no'
in this case, as this layer only cares about metadata in current
version to be able to detect dirty datas tatus.

Signed-off-by: Adam Rutkowski <adam.j.rutkowski@intel.com>