### PR TITLE
casadm: don't cast a float to an int explicitly

### DIFF
--- a/casadm/Makefile
+++ b/casadm/Makefile
@@ -83,7 +83,7 @@ CFLAGS    += -Wall -Werror -z relro -z now -fstack-protector -fPIC -Wformat -Wfo
 #
 # Flags for linking
 #
-LDFLAGS    = -z noexecstack -z relro -z now -pie -pthread
+LDFLAGS    = -z noexecstack -z relro -z now -pie -pthread -lm
 #
 # Targets
 #

--- a/casadm/cas_lib.c
+++ b/casadm/cas_lib.c
@@ -38,6 +38,7 @@
 #include "psort.h"
 #include <libgen.h>
 #include <regex.h>
+#include <math.h>
 
 #define PRINT_STAT(x) header->cmd_input.cache_stats.x
 
@@ -2212,7 +2213,7 @@ static int calculate_max_allocation(uint16_t cache_id, const char *allocation,
 	if (allocation + strnlen(allocation, MAX_STR_LEN) != end)
 		return FAILURE;
 
-	*part_size = (uint32_t)(alloc * 100);
+	*part_size = (uint32_t)round(alloc * 100);
 
 	return SUCCESS;
 }


### PR DESCRIPTION
If an underflowed float number was casted to an int explicitly, it's value was
rounded to a lower value.

Using `round()` function ensures that the number will be always rounded to a
nearest integer.

Signed-off-by: Michal Mielewczyk <michal.mielewczyk@intel.com>