### PR TITLE
Print warning about incompatible modules

### DIFF
--- a/utils/pckgen.d/rpm/CAS_NAME.spec
+++ b/utils/pckgen.d/rpm/CAS_NAME.spec
@@ -91,7 +91,15 @@ if [[ ! "$ID_LIKE" =~ suse|sles ]]; then
             modules+=( $(realpath "$file") )
         fi
     done
+    # Pass modules location to weak-modules...
     printf "%s\n" "${modules[@]}" | weak-modules --no-initramfs --add-modules
+    # ...and check if symlinks were created in case of different kernel version
+    for module in "${modules[@]}"; do
+        if [[ ! $(find /lib/modules/$(uname -r)/ -name $(basename "$module") 2>/dev/null) ]]; then
+            echo "WARNING: CAS module '$(basename $module)' is not" \
+                 "compatible with current kernel version $(uname -r)"
+        fi
+    done
 fi
 
 %preun modules_%{kver_filename}


### PR DESCRIPTION
During installation from RPM, inform user about modules that are
incompatible with current kernel version. This concerns modules that
failed to be linked by weak-modules script.

Signed-off-by: Rafal Stefanowski <rafal.stefanowski@intel.com>