### PR TITLE
Fix for building OpenCAS

### DIFF
--- a/casadm/Makefile
+++ b/casadm/Makefile
@@ -101,7 +101,7 @@ sync:
 #
 $(TARGET): $(TARGET).a
 	@echo "  LD " $@
-	@$(CC) $(CFLAGS) $(LDFLAGS) -o $(TARGET) $<
+	@$(CC) $(CFLAGS) -o $(TARGET) $< $(LDFLAGS)
 
 $(TARGET).a: $(patsubst %,$(OBJDIR)%,$(OBJS))
 	@echo "  AR " $@


### PR DESCRIPTION
On some systems, e.g. Ubuntu, the order of linking `math` library is
important and when linking is done too early, openCAS making fails.

Signed-off-by: Slawomir Jankowski <slawomir.jankowski@intel.com>

Fixes #668