### PR TITLE
Allocators revamp

### DIFF
--- a/modules/cas_cache/ocf_env.h
+++ b/modules/cas_cache/ocf_env.h
@@ -78,6 +78,9 @@ static inline void env_secure_free(const void *ptr, size_t size)
 
 typedef struct _env_allocator env_allocator;
 
+env_allocator *env_allocator_create_extended(uint32_t size, const char *name,
+	int rpool_limit);
+
 env_allocator *env_allocator_create(uint32_t size, const char *name);
 
 void env_allocator_destroy(env_allocator *allocator);

--- a/modules/cas_cache/ocf_env.h
+++ b/modules/cas_cache/ocf_env.h
@@ -10,6 +10,7 @@
 #include "linux_kernel_version.h"
 #include "utils/utils_gc.h"
 #include "ocf/ocf_err.h"
+#include "utils/utils_mpool.h"
 
 /* linux sector 512-bytes */
 #define ENV_SECTOR_SHIFT	9


### PR DESCRIPTION
To improve allocations in OCF we need more flexible ways to allocate memory such as mpools. Also to reduce memory footprint we can reduce initial allocations for rpools backing the allocators.