### PR TITLE
python3.6+ is needed for casctl

### DIFF
--- a/utils/casctl
+++ b/utils/casctl
@@ -10,8 +10,8 @@ import sys
 
 import opencas
 
-if sys.version_info < (3, 5):
-    raise RuntimeError('At least Python 3.5 is required')
+if sys.version_info < (3, 6):
+    raise RuntimeError('At least Python 3.6 is required')
 
 def eprint(*args, **kwargs):
     print(*args, file=sys.stderr, **kwargs)


### PR DESCRIPTION
opencas.py uses the f-string feature of python3.6+.

Signed-off-by: Sha Fanghao <shafanghao@gmail.com>