### PR TITLE
improving get_core_info() method -test_attach_core_to_incomplete_cache_volume fix

### DIFF
--- a/test/functional/tests/incremental_load/test_incremental_load.py
+++ b/test/functional/tests/incremental_load/test_incremental_load.py
@@ -5,6 +5,7 @@
 
 import time
 from random import shuffle
+
 import pytest
 
 from api.cas import casadm, cli, cli_messages


### PR DESCRIPTION
Getting core device id before unplug for later validation of core inactive status

Signed-off-by: Karolina Rogowska <karolina.rogowska@intel.com>