### PR TITLE
longer io in test_soft_hot_plug_device

### DIFF
--- a/test/functional/tests/fault_injection/test_soft_hot_plug_device.py
+++ b/test/functional/tests/fault_injection/test_soft_hot_plug_device.py
@@ -5,17 +5,18 @@
 
 
 import time
+from datetime import timedelta
+
 import pytest
 
-from datetime import timedelta
 from api.cas import casadm
 from api.cas.cache_config import CacheMode
-from storage_devices.disk import DiskType, DiskTypeSet, DiskTypeLowerThan
 from core.test_run import TestRun
-from test_utils.size import Size, Unit
-from test_utils.output import CmdException
+from storage_devices.disk import DiskType, DiskTypeSet, DiskTypeLowerThan
 from test_tools.fio.fio import Fio
 from test_tools.fio.fio_param import ReadWrite, IoEngine, ErrorFilter
+from test_utils.output import CmdException
+from test_utils.size import Size, Unit
 
 
 @pytest.mark.parametrizex("cache_mode", CacheMode)
@@ -208,7 +209,7 @@ def fio_prepare(core):
         .target(core.path)
         .continue_on_error(ErrorFilter.io)
         .direct(1)
-        .run_time(timedelta(seconds=30))
+        .run_time(timedelta(seconds=120))
         .time_based()
     )
     return fio


### PR DESCRIPTION
Fix for problem: io ended before core disappeared from the system after unplug so then were no errors counted/detected.

Signed-off-by: Karolina Rogowska <karolina.rogowska@intel.com>