### PR TITLE
Fix _blockdev_set_bio_data iteration

### DIFF
--- a/modules/cas_cache/volume/vol_block_dev_top.c
+++ b/modules/cas_cache/volume/vol_block_dev_top.c
@@ -38,11 +38,12 @@ static void _blockdev_set_bio_data(struct blk_data *data, struct bio *bio)
 {
 #if LINUX_VERSION_CODE < KERNEL_VERSION(3, 14, 0)
 	struct bio_vec *bvec;
-	uint32_t i = 0;
+	uint32_t iter = 0, i = 0;
 
-	bio_for_each_segment(bvec, bio, i) {
+	bio_for_each_segment(bvec, bio, iter) {
 		BUG_ON(i >= data->size);
 		data->vec[i] = *bvec;
+		i++;
 	}
 #else
 	struct bio_vec bvec;


### PR DESCRIPTION
The data->size field can be initialized to a lower value than bio->bi_vcnt,
if the bio is split. The bio_for_each_segment then iterates based on the original
indexes and the mismatch eventually causes a BUG_ON.

Fixes #714

Signed-off-by: Kozlowski Mateusz <mateusz.kozlowski@intel.com>