### PR TITLE
Set proper multiqueue flags

### DIFF
--- a/configure.d/1_mq_flags.conf
+++ b/configure.d/1_mq_flags.conf
@@ -1,0 +1,34 @@
+#!/bin/bash
+#
+# Copyright(c) 2012-2021 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+#
+
+. $(dirname $3)/conf_framework
+
+check() {
+	cur_name=$(basename $2)
+	config_file_path=$1
+	if compile_module $cur_name "BLK_MQ_F_STACKING " "linux/blk-mq.h"
+	then
+		echo $cur_name "1" >> $config_file_path
+	else
+		echo $cur_name "2" >> $config_file_path
+	fi
+}
+
+apply() {
+    case "$1" in
+    "1")
+		add_define "CAS_BLK_MQ_F_STACKING \\
+			BLK_MQ_F_STACKING"
+		;;
+    "2")
+		add_define "CAS_BLK_MQ_F_STACKING 0"
+		;;
+    *)
+        exit 1
+    esac
+}
+
+conf_run $@

--- a/modules/cas_disk/exp_obj.c
+++ b/modules/cas_disk/exp_obj.c
@@ -526,7 +526,7 @@ static int _casdsk_init_tag_set(struct casdsk_disk *dsk, struct blk_mq_tag_set *
 	set->queue_depth = BLKDEV_MAX_RQ;
 
 	set->cmd_size = 0;
-	set->flags = BLK_MQ_F_SHOULD_MERGE;
+	set->flags = BLK_MQ_F_SHOULD_MERGE | CAS_BLK_MQ_F_STACKING | BLK_MQ_F_BLOCKING;
 
 	set->driver_data = dsk;
 


### PR DESCRIPTION
Setting BLK_MQ_F_STACKING (to indicate stacked device) and
BLK_MQ_F_BLOCKING (to indicate potentially blocking operations
like acquiring mutex or GFP_NOIO allocations).

Signed-off-by: Adam Rutkowski <adam.j.rutkowski@intel.com>