### PR TITLE
Fix adding core after core addition failure

### DIFF
--- a/modules/cas_cache/cas_cache.h
+++ b/modules/cas_cache/cas_cache.h
@@ -70,7 +70,7 @@ extern ocf_ctx_t cas_ctx;
 extern struct casdsk_functions_mapper casdisk_functions;
 
 struct casdsk_functions_mapper {
-	int (*casdsk_disk_dettach)(struct casdsk_disk *dsk);
+	int (*casdsk_disk_detach)(struct casdsk_disk *dsk);
 	int (*casdsk_exp_obj_destroy)(struct casdsk_disk *dsk);
 	int (*casdsk_exp_obj_create)(struct casdsk_disk *dsk, const char *dev_name,
 		struct module *owner, struct casdsk_exp_obj_ops *ops);

--- a/modules/cas_cache/main.c
+++ b/modules/cas_cache/main.c
@@ -89,7 +89,7 @@ int static cas_find_symbol(void *data, const char *namebuf,
 int static cas_casdisk_lookup_funtions(void)
 {
 	mutex_lock(&module_mutex);
-	cas_lookup_symbol(casdsk_disk_dettach);
+	cas_lookup_symbol(casdsk_disk_detach);
 	cas_lookup_symbol(casdsk_exp_obj_destroy);
 	cas_lookup_symbol(casdsk_exp_obj_create);
 	cas_lookup_symbol(casdsk_exp_obj_free);

--- a/modules/cas_cache/volume/vol_block_dev_bottom.c
+++ b/modules/cas_cache/volume/vol_block_dev_bottom.c
@@ -66,7 +66,7 @@ void block_dev_close_object(ocf_volume_t vol)
 		casdisk_functions.casdsk_disk_close(bdobj->dsk);
 	} else {
 		casdisk_functions.casdsk_disk_set_pt(bdobj->dsk);
-		casdisk_functions.casdsk_disk_dettach(bdobj->dsk);
+		casdisk_functions.casdsk_disk_detach(bdobj->dsk);
 	}
 }
 

--- a/modules/cas_disk/cas_disk.h
+++ b/modules/cas_disk/cas_disk.h
@@ -177,11 +177,11 @@ int casdsk_disk_set_attached(struct casdsk_disk *dsk);
 int casdsk_disk_clear_pt(struct casdsk_disk *dsk);
 
 /**
- * @brief Dettach cas from cas_disk device
+ * @brief Detach cas from cas_disk device
  * @param dsk Pointer to casdsk_disk structure related to cas_disk device
  * @return 0 if success, errno if failure
  */
-int casdsk_disk_dettach(struct casdsk_disk *dsk);
+int casdsk_disk_detach(struct casdsk_disk *dsk);
 
 /**
  * @brief Attach cas to cas_disk device
@@ -231,7 +231,7 @@ int casdsk_exp_obj_activate(struct casdsk_disk *dsk);
  * @param dsk Pointer to casdsk_disk structure related to cas_disk device
  * @return true if exported object is active
  */
-bool casdsk_exp_obj_activated(struct casdsk_disk *ds);
+bool casdsk_exp_obj_activated(struct casdsk_disk *dsk);
 
 /**
  * @brief Lock exported object

--- a/modules/cas_disk/disk.c
+++ b/modules/cas_disk/disk.c
@@ -377,7 +377,7 @@ int casdsk_disk_clear_pt(struct casdsk_disk *dsk)
 }
 EXPORT_SYMBOL(casdsk_disk_clear_pt);
 
-static inline int __casdsk_disk_dettach(struct casdsk_disk *dsk)
+static inline int __casdsk_disk_detach(struct casdsk_disk *dsk)
 {
 	int result;
 
@@ -385,7 +385,7 @@ static inline int __casdsk_disk_dettach(struct casdsk_disk *dsk)
 
 	atomic_set(&dsk->mode, CASDSK_MODE_PT);
 
-	result = casdsk_exp_obj_dettach(dsk);
+	result = casdsk_exp_obj_detach(dsk);
 	if (result) {
 		atomic_set(&dsk->mode, CASDSK_MODE_ATTACHED);
 		return result;
@@ -394,7 +394,7 @@ static inline int __casdsk_disk_dettach(struct casdsk_disk *dsk)
 	return 0;
 }
 
-int casdsk_disk_dettach(struct casdsk_disk *dsk)
+int casdsk_disk_detach(struct casdsk_disk *dsk)
 {
 	int result;
 
@@ -405,13 +405,13 @@ int casdsk_disk_dettach(struct casdsk_disk *dsk)
 		return 0;
 
 	casdsk_disk_lock(dsk);
-	result = __casdsk_disk_dettach(dsk);
+	result = __casdsk_disk_detach(dsk);
 	casdsk_disk_unlock(dsk);
 
 	return result;
 
 }
-EXPORT_SYMBOL(casdsk_disk_dettach);
+EXPORT_SYMBOL(casdsk_disk_detach);
 
 static inline int __casdsk_disk_attach(struct casdsk_disk *dsk,
 		struct module *owner, struct casdsk_exp_obj_ops *ops)

--- a/modules/cas_disk/exp_obj.c
+++ b/modules/cas_disk/exp_obj.c
@@ -816,7 +816,7 @@ int casdsk_exp_obj_destroy(struct casdsk_disk *dsk)
 }
 EXPORT_SYMBOL(casdsk_exp_obj_destroy);
 
-int casdsk_exp_obj_dettach(struct casdsk_disk *dsk)
+int casdsk_exp_obj_detach(struct casdsk_disk *dsk)
 {
 	module_put(dsk->exp_obj->owner);
 

--- a/modules/cas_disk/exp_obj.c
+++ b/modules/cas_disk/exp_obj.c
@@ -623,8 +623,7 @@ int casdsk_exp_obj_create(struct casdsk_disk *dsk, const char *dev_name,
 	return 0;
 
 error_set_geometry:
-	if (exp_obj->ops->cleanup_queue)
-		exp_obj->ops->cleanup_queue(dsk, queue, dsk->private);
+	blk_cleanup_queue(exp_obj->queue);
 error_init_queue:
 	blk_mq_free_tag_set(&dsk->tag_set);
 error_init_tag_set:

--- a/modules/cas_disk/exp_obj.h
+++ b/modules/cas_disk/exp_obj.h
@@ -42,7 +42,7 @@ void casdsk_deinit_exp_objs(void);
 
 void casdsk_exp_obj_free(struct casdsk_disk *dsk);
 
-int casdsk_exp_obj_dettach(struct casdsk_disk *dsk);
+int casdsk_exp_obj_detach(struct casdsk_disk *dsk);
 int casdsk_exp_obj_attach(struct casdsk_disk *dsk, struct module *owner,
 			struct casdsk_exp_obj_ops *ops);
 void casdsk_exp_obj_prepare_pt(struct casdsk_disk *dsk);


### PR DESCRIPTION
caused by disallowed logical block size mismatch.

Cleanup exported object queue 
This patch fixes adding core after core addition failure.
The queue wasn't cleaned before and following core addition cannot
re-initialize queue properly.

Fixes #808

Signed-off-by: Slawomir Jankowski <slawomir.jankowski@intel.com>