### PR TITLE
[21.3.2] Fix adding core after core addition failure

### DIFF
--- a/modules/cas_cache/volume/vol_block_dev_top.c
+++ b/modules/cas_cache/volume/vol_block_dev_top.c
@@ -596,6 +596,18 @@ static void _blockdev_set_discard_properties(ocf_cache_t cache,
 	}
 }
 
+static void _blockdev_cleanup_queue(struct casdsk_disk *dsk)
+{
+	struct request_queue *exp_obj_q = NULL;
+
+	exp_obj_q = casdisk_functions.casdsk_exp_obj_get_queue(dsk);
+	BUG_ON(!exp_obj_q);
+
+	if (exp_obj_q) {
+		blk_cleanup_queue(exp_obj_q);
+	}
+}
+
 /**
  * Map geometry of underlying (core) object geometry (sectors etc.)
  * to geometry of exported object.
@@ -804,6 +816,7 @@ err:
 }
 
 static struct casdsk_exp_obj_ops _blockdev_exp_obj_ops = {
+	.cleanup_queue = _blockdev_cleanup_queue,
 	.set_geometry = _blockdev_set_geometry,
 	.make_request_fn = _blockdev_make_request_fast,
 	.queue_rq_fn = _block_dev_queue_request,

--- a/modules/cas_disk/cas_disk.h
+++ b/modules/cas_disk/cas_disk.h
@@ -31,8 +31,7 @@ struct casdsk_exp_obj_ops {
 	 * @brief Cleanup request queue of exported object (top) block device.
 	 *	Could be NULL.
 	 */
-	void (*cleanup_queue)(struct casdsk_disk *dsk, struct request_queue *q,
-			      void *private);
+	void (*cleanup_queue)(struct casdsk_disk *dsk);
 
 	/**
 	 * @brief Set geometry of exported object (top) block device.

--- a/modules/cas_disk/exp_obj.c
+++ b/modules/cas_disk/exp_obj.c
@@ -624,7 +624,7 @@ int casdsk_exp_obj_create(struct casdsk_disk *dsk, const char *dev_name,
 
 error_set_geometry:
 	if (exp_obj->ops->cleanup_queue)
-		exp_obj->ops->cleanup_queue(dsk, queue, dsk->private);
+		exp_obj->ops->cleanup_queue(dsk);
 error_init_queue:
 	blk_mq_free_tag_set(&dsk->tag_set);
 error_init_tag_set:


### PR DESCRIPTION
caused by disallowed logical block size mismatch.

Implement and use queue cleanup for exported object
This patch fixes adding core after core addition failure.
The queue wasn't cleaned before and following core addition cannot
re-initialize queue properly.
I assumed that less is better so I removed unused parameters from
existing `cleanup_queue` placeholder.

Signed-off-by: Slawomir Jankowski <slawomir.jankowski@intel.com>