### PR TITLE
Update OCF

### DIFF
--- a/casadm/cas_lib.h
+++ b/casadm/cas_lib.h
@@ -91,7 +91,6 @@ enum metadata_mode_t {
 
 #define STATS_FILTER_COUNTERS (STATS_FILTER_REQ | STATS_FILTER_BLK | STATS_FILTER_ERR)
 
-const char *eviction_policy_to_name(uint8_t policy);
 const char *cleaning_policy_to_name(uint8_t policy);
 const char *promotion_policy_to_name(uint8_t policy);
 const char *cache_mode_to_name(uint8_t cache_mode);
@@ -122,7 +121,6 @@ void metadata_memory_footprint(uint64_t size, float *footprint, const char **uni
 
 int start_cache(uint16_t cache_id, unsigned int cache_init,
 		const char *cache_device, ocf_cache_mode_t cache_mode,
-		ocf_eviction_t eviction_policy_type,
 		ocf_cache_line_size_t line_size, int force);
 int stop_cache(uint16_t cache_id, int flush);
 
@@ -264,7 +262,6 @@ int validate_str_unum(const char *source_str, const char *msg, unsigned int min,
 int validate_path(const char *path, int exist);
 
 int validate_str_cache_mode(const char *s);
-int validate_str_ev_policy(const char *s);
 int validate_str_cln_policy(const char *s);
 int validate_str_promotion_policy(const char *s);
 int validate_str_meta_variant(const char *s);

--- a/casadm/cas_main.c
+++ b/casadm/cas_main.c
@@ -44,7 +44,6 @@ struct command_args{
 	int stats_filters;
 	int output_format;
 	int io_class_id;
-	int eviction_policy_type;
 	int line_size;
 	int cache_state_flush;
 	int flush_data;
@@ -138,11 +137,6 @@ int command_handle_option(char *opt, const char **arg)
 		command_args_values.cleaning_policy_type = validate_str_cln_policy((const char*)arg[0]);
 
 		if (command_args_values.cleaning_policy_type < 0)
-			return FAILURE;
-	} else if (!strcmp(opt, "eviction-policy")) {
-		command_args_values.eviction_policy_type = validate_str_ev_policy((const char*)arg[0]);
-
-		if (command_args_values.eviction_policy_type < 0)
 			return FAILURE;
 	} else if (!strcmp(opt, "try-add")) {
 		command_args_values.try_add = true;
@@ -336,7 +330,6 @@ int handle_start()
 			command_args_values.state,
 			command_args_values.cache_device,
 			command_args_values.cache_mode,
-			command_args_values.eviction_policy_type,
 			command_args_values.line_size,
 			command_args_values.force);
 

--- a/casadm/statistics_model.c
+++ b/casadm/statistics_model.c
@@ -498,7 +498,7 @@ int cache_stats_ioclasses(int ctrl_fd, const struct kcas_cache_info *cache_info,
 		return SUCCESS;
 	}
 
-	for (part_iter_id = 0; part_iter_id < OCF_IO_CLASS_MAX; part_iter_id++) {
+	for (part_iter_id = 0; part_iter_id < OCF_USER_IO_CLASS_MAX; part_iter_id++) {
 		info.cache_id = cache_id;
 		info.class_id = part_iter_id;
 		stats.cache_id = cache_id;
@@ -567,8 +567,6 @@ int cache_stats_conf(int ctrl_fd, const struct kcas_cache_info *cache_info,
 
 	print_kv_pair(outfile, "Write Policy", "%s",
 		      cache_mode_to_name(cache_info->info.cache_mode));
-	print_kv_pair(outfile, "Eviction Policy", "%s",
-		      eviction_policy_to_name(cache_info->info.eviction_policy));
 	print_kv_pair(outfile, "Cleaning Policy", "%s",
 		      cleaning_policy_to_name(cache_info->info.cleaning_policy));
 	print_kv_pair(outfile, "Promotion Policy", "%s",

--- a/modules/cas_cache/classifier.c
+++ b/modules/cas_cache/classifier.c
@@ -1121,7 +1121,7 @@ int cas_cls_init(ocf_cache_t cache)
 
 	/* Update rules for all I/O classes except 0 - this is default for all
 	 * unclassified I/O */
-	for (i = 1; i < OCF_IO_CLASS_MAX; i++) {
+	for (i = 1; i < OCF_USER_IO_CLASS_MAX; i++) {
 		result = _cas_cls_rule_init(cache, i);
 		if (result)
 			break;

--- a/modules/cas_cache/context.c
+++ b/modules/cas_cache/context.c
@@ -282,21 +282,6 @@ static void _cas_ctx_cleaner_stop(ocf_cleaner_t c)
 	return cas_stop_cleaner_thread(c);
 }
 
-static int _cas_ctx_metadata_updater_init(ocf_metadata_updater_t mu)
-{
-	return cas_create_metadata_updater_thread(mu);
-}
-
-static void _cas_ctx_metadata_updater_kick(ocf_metadata_updater_t mu)
-{
-	return cas_kick_metadata_updater_thread(mu);
-}
-
-static void _cas_ctx_metadata_updater_stop(ocf_metadata_updater_t mu)
-{
-	return cas_stop_metadata_updater_thread(mu);
-}
-
 #define CAS_LOG_FORMAT_STRING_MAX_LEN 256
 
 static int _cas_ctx_logger_open(ocf_logger_t logger)
@@ -406,12 +391,6 @@ static const struct ocf_ctx_config ctx_cfg = {
 			.stop = _cas_ctx_cleaner_stop,
 		},
 
-		.metadata_updater = {
-			.init = _cas_ctx_metadata_updater_init,
-			.kick = _cas_ctx_metadata_updater_kick,
-			.stop = _cas_ctx_metadata_updater_stop,
-		},
-
 		.logger = {
 			.open = _cas_ctx_logger_open,
 			.close = _cas_ctx_logger_close,
@@ -434,7 +413,7 @@ int cas_initialize_context(void)
 
 	cas_bvec_pool = env_mpool_create(sizeof(struct blk_data),
 			sizeof(struct bio_vec), GFP_NOIO, 7, true, NULL,
-			"cas_biovec");
+			"cas_biovec", true);
 
 	if (!cas_bvec_pool) {
 		printk(KERN_ERR "Cannot create BIO vector memory pool\n");

--- a/modules/cas_cache/layer_cache_management.c
+++ b/modules/cas_cache/layer_cache_management.c
@@ -2048,7 +2048,7 @@ int cache_mngt_init_instance(struct ocf_mngt_cache_config *cfg,
 	/* Start cache. Returned cache instance will be locked as it was set
 	 * in configuration.
 	 */
-	result = ocf_mngt_cache_start(cas_ctx, &cache, cfg);
+	result = ocf_mngt_cache_start(cas_ctx, &cache, cfg, NULL);
 	if (result) {
 		kthread_stop(context->rollback_thread);
 		kfree(context);

--- a/modules/cas_cache/layer_cache_management.c
+++ b/modules/cas_cache/layer_cache_management.c
@@ -1584,16 +1584,16 @@ int cache_mngt_set_partitions(const char *cache_name, size_t name_len,
 {
 	ocf_cache_t cache;
 	struct ocf_mngt_io_classes_config *io_class_cfg;
-	struct cas_cls_rule *cls_rule[OCF_IO_CLASS_MAX];
+	struct cas_cls_rule *cls_rule[OCF_USER_IO_CLASS_MAX];
 	ocf_part_id_t class_id;
 	int result;
 
 	io_class_cfg = kzalloc(sizeof(struct ocf_mngt_io_class_config) *
-			OCF_IO_CLASS_MAX, GFP_KERNEL);
+			OCF_USER_IO_CLASS_MAX, GFP_KERNEL);
 	if (!io_class_cfg)
 		return -OCF_ERR_NO_MEM;
 
-	for (class_id = 0; class_id < OCF_IO_CLASS_MAX; class_id++) {
+	for (class_id = 0; class_id < OCF_USER_IO_CLASS_MAX; class_id++) {
 		io_class_cfg->config[class_id].class_id = class_id;
 
 		if (!cfg->info[class_id].name[0]) {
@@ -1610,7 +1610,7 @@ int cache_mngt_set_partitions(const char *cache_name, size_t name_len,
 	if (result)
 		goto out_get;
 
-	for (class_id = 0; class_id < OCF_IO_CLASS_MAX; class_id++) {
+	for (class_id = 0; class_id < OCF_USER_IO_CLASS_MAX; class_id++) {
 		result = cas_cls_rule_create(cache, class_id,
 				cfg->info[class_id].name,
 				&cls_rule[class_id]);
@@ -1632,7 +1632,7 @@ int cache_mngt_set_partitions(const char *cache_name, size_t name_len,
 	if (result)
 		goto out_configure;
 
-	for (class_id = 0; class_id < OCF_IO_CLASS_MAX; class_id++)
+	for (class_id = 0; class_id < OCF_USER_IO_CLASS_MAX; class_id++)
 		cas_cls_rule_apply(cache, class_id, cls_rule[class_id]);
 
 out_configure:
@@ -1712,7 +1712,6 @@ int cache_mngt_prepare_cache_cfg(struct ocf_mngt_cache_config *cfg,
 	strncpy(cfg->name, cache_name, OCF_CACHE_NAME_SIZE - 1);
 	cfg->cache_mode = cmd->caching_mode;
 	cfg->cache_line_size = cmd->line_size;
-	cfg->eviction_policy = cmd->eviction_policy;
 	cfg->promotion_policy = ocf_promotion_default;
 	cfg->cache_line_size = cmd->line_size;
 	cfg->pt_unaligned_io = !unaligned_io;

--- a/modules/cas_cache/ocf_env.c
+++ b/modules/cas_cache/ocf_env.c
@@ -174,7 +174,7 @@ err:
 	return NULL;
 }
 
-env_allocator *env_allocator_create(uint32_t size, const char *name)
+env_allocator *env_allocator_create(uint32_t size, const char *name, bool zero)
 {
 	return env_allocator_create_extended(size, name, -1);
 }

--- a/modules/cas_cache/ocf_env.h
+++ b/modules/cas_cache/ocf_env.h
@@ -82,7 +82,7 @@ typedef struct _env_allocator env_allocator;
 env_allocator *env_allocator_create_extended(uint32_t size, const char *name,
 	int rpool_limit);
 
-env_allocator *env_allocator_create(uint32_t size, const char *name);
+env_allocator *env_allocator_create(uint32_t size, const char *name, bool zero);
 
 void env_allocator_destroy(env_allocator *allocator);
 

--- a/modules/cas_cache/threads.h
+++ b/modules/cas_cache/threads.h
@@ -20,8 +20,4 @@ int cas_create_cleaner_thread(ocf_cleaner_t c);
 void cas_kick_cleaner_thread(ocf_cleaner_t c);
 void cas_stop_cleaner_thread(ocf_cleaner_t c);
 
-int cas_create_metadata_updater_thread(ocf_metadata_updater_t mu);
-void cas_kick_metadata_updater_thread(ocf_metadata_updater_t mu);
-void cas_stop_metadata_updater_thread(ocf_metadata_updater_t mu);
-
 #endif /* __THREADS_H__ */

--- a/modules/cas_cache/utils/utils_mpool.c
+++ b/modules/cas_cache/utils/utils_mpool.c
@@ -29,7 +29,7 @@ struct env_mpool {
 struct env_mpool *env_mpool_create(uint32_t hdr_size, uint32_t elem_size,
 		int flags, int mpool_max, bool fallback,
 		const uint32_t limits[env_mpool_max],
-		const char *name_perfix)
+		const char *name_perfix, bool zero)
 {
 	uint32_t i;
 	char name[MPOOL_ALLOCATOR_NAME_MAX] = { '\0' };

--- a/modules/cas_cache/utils/utils_mpool.h
+++ b/modules/cas_cache/utils/utils_mpool.h
@@ -37,13 +37,14 @@ struct env_mpool;
  * 		order or NULL if defaults are to be used. Array should have
  * 		mpool_max elements
  * @param name_prefix Format name prefix
+ * @param zero Unused parameter
  *
  * @return CAS memory pool
  */
 struct env_mpool *env_mpool_create(uint32_t hdr_size, uint32_t elem_size,
 		int flags, int mpool_max, bool fallback,
 		const uint32_t limits[env_mpool_max],
-		const char *name_perfix);
+		const char *name_prefix, bool zero);
 
 /**
  * @brief Destroy existing memory pool

--- a/modules/include/cas_ioctl_codes.h
+++ b/modules/include/cas_ioctl_codes.h
@@ -63,11 +63,6 @@ struct kcas_start_cache {
 	 */
 	ocf_cache_mode_t caching_mode;
 
-	/**
-	 * eviction policy to be used for newely configured cache instance.
-	 */
-	ocf_eviction_t eviction_policy;
-
 	uint8_t flush_data; /**< should data be flushed? */
 
 	/**
@@ -269,7 +264,7 @@ struct kcas_io_classes {
 };
 
 #define KCAS_IO_CLASSES_SIZE (sizeof(struct kcas_io_classes) \
-		+ OCF_IO_CLASS_MAX * sizeof(struct ocf_io_class_info))
+		+ OCF_USER_IO_CLASS_MAX * sizeof(struct ocf_io_class_info))
 
 /**
  * structure in which result of KCAS_IOCTL_LIST_CACHE is supplied from kernel module.

--- a/test/smoke_test/metadata_corrupt/01
+++ b/test/smoke_test/metadata_corrupt/01
@@ -42,7 +42,7 @@ TARGET_DEVICE_OPTION="$CACHE_DEVICE" PARTITION_SIZE_OPTION="2000M" PARTITION_IDS
 # Create 1 primary partition on CORE_DEVICE, 4000M
 TARGET_DEVICE_OPTION="$CORE_DEVICE" PARTITION_SIZE_OPTION="4000M" PARTITION_IDS_OPTION="1" make_primary_partitions
 
-METADATA_SECTIONS_NAMES=("Super block config" "Super block runtime" "Reserved" "Cleaning" "Eviction" "Collision" "List info" "Hash" "Core config" "Core runtime" "Core UUID")
+METADATA_SECTIONS_NAMES=("Super block config" "Super block runtime" "Reserved" "Cleaning" "LRU list" "Collision" "List info" "Hash" "Core config" "Core runtime" "Core UUID")
 
 for SECTION in "${METADATA_SECTIONS_NAMES[@]}"
 do

--- a/test/smoke_test/metadata_corrupt/02
+++ b/test/smoke_test/metadata_corrupt/02
@@ -30,7 +30,7 @@ TARGET_DEVICE_OPTION="$CACHE_DEVICE" PARTITION_SIZE_OPTION="2000M" PARTITION_IDS
 # Create 1 primary partition on CORE_DEVICE, 4000M
 TARGET_DEVICE_OPTION="$CORE_DEVICE" PARTITION_SIZE_OPTION="4000M" PARTITION_IDS_OPTION="1" make_primary_partitions
 
-METADATA_SECTIONS_NAMES=("Super block config" "Super block runtime" "Reserved" "Cleaning" "Eviction" "Collision" "List info" "Hash" "Core config" "Core runtime" "Core UUID")
+METADATA_SECTIONS_NAMES=("Super block config" "Super block runtime" "Reserved" "Cleaning" "LRU list" "Collision" "List info" "Hash" "Core config" "Core runtime" "Core UUID")
 
 for SECTION in "${METADATA_SECTIONS_NAMES[@]}"
 do


### PR DESCRIPTION
Adapter changes for latest OCF

1. Remove metadata updater
2. Update mpool API
3. Remove configurable eviction policy

Signed-off-by: Kozlowski Mateusz <mateusz.kozlowski@intel.com>