### PR TITLE
tools: Introduce version2sha helper tool

### DIFF
--- a/tools/version2sha
+++ b/tools/version2sha
@@ -1,0 +1,13 @@
+#!/bin/bash
+#
+# Copyright(c) 2021 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+#
+
+VERSION=$1
+MERGE=$(echo "$VERSION" | cut -d. -f 4)
+SHA=$(git log --merges --oneline | tac | sed "${MERGE}q;d" | cut -d " " -f 1)
+
+[[ -z "$SHA" ]] && exit 1
+
+echo "$SHA"


### PR DESCRIPTION
This tool translates Open CAS version tag into SHA in git repository.
Example:

$ ./tools/version2sha 21.06.0.0520.master
eaa2f54

Signed-off-by: Robert Baldyga <robert.baldyga@intel.com>