### PR TITLE
[v21.3.3] Use blk_plug mechanism in bottom block adapter

### DIFF
--- a/modules/cas_cache/volume/vol_block_dev_bottom.c
+++ b/modules/cas_cache/volume/vol_block_dev_bottom.c
@@ -3,6 +3,8 @@
 * SPDX-License-Identifier: BSD-3-Clause-Clear
 */
 
+#include <linux/blkdev.h>
+
 #include "cas_cache.h"
 
 #define CAS_DEBUG_IO 0
@@ -411,6 +413,7 @@ static void block_dev_submit_io(struct ocf_io *io)
 	uint64_t addr = io->addr;
 	uint32_t bytes = io->bytes;
 	int dir = io->dir;
+	struct blk_plug plug;
 
 	if (!CAS_IS_WRITE_FLUSH_FUA(io->flags) &&
 			CAS_IS_WRITE_FLUSH(io->flags)) {
@@ -434,6 +437,8 @@ static void block_dev_submit_io(struct ocf_io *io)
 		cas_bd_io_end(io, -EINVAL);
 		return;
 	}
+
+	blk_start_plug(&plug);
 
 	while (cas_io_iter_is_next(iter) && bytes) {
 		/* Still IO vectors to be sent */
@@ -501,6 +506,8 @@ static void block_dev_submit_io(struct ocf_io *io)
 			break;
 		}
 	}
+
+	blk_finish_plug(&plug);
 
 	if (bytes && bdio->error == 0) {
 		/* Not all bytes sent, mark error */


### PR DESCRIPTION
This is a suboptimal solution to CAS on top of MD RAID1 device. If using
only submit_bio API RAID1 would process all IOs in single thread.
Plugging bypasses this thread and processess IOs in blk_finish_plug
caller context improving performance drastically.

Testing showed no negative impact to other usecases and it's a thing
that Linux does in AIO, so it's vetted and proven to work.

Signed-off-by: Jan Musial <jan.musial@intel.com>