### PR TITLE
[v21.3.3] Return mempool instead of enum

### DIFF
--- a/modules/cas_cache/utils/utils_mpool.c
+++ b/modules/cas_cache/utils/utils_mpool.c
@@ -88,7 +88,7 @@ static env_allocator *env_mpool_get_allocator(
 	unsigned int idx;
 
 	if (unlikely(count == 0))
-		return env_mpool_1;
+		return mallocator->allocator[env_mpool_1];
 
 	idx = 31 - __builtin_clz(count);
 


### PR DESCRIPTION
Signed-off-by: Michal Mielewczyk <michal.mielewczyk@intel.com>
Signed-off-by: Robert Baldyga <robert.baldyga@intel.com>