### PR TITLE
Add CAS log dump to extra logs

### DIFF
--- a/test/functional/tests/conftest.py
+++ b/test/functional/tests/conftest.py
@@ -33,6 +33,7 @@ class Opencas(metaclass=Singleton):
         self.repo_dir = repo_dir
         self.working_dir = working_dir
         self.already_updated = False
+        self.logs_to_dump = {"cas": "/var/log/opencas.log"}
 
 
 def pytest_runtest_setup(item):


### PR DESCRIPTION
Commit 51a8fca8872808c0809ef715c9b6a8d19b9310f3 in test-framework
adds possibility to specify extra logs to dump.
Move CAS log to these extra logs, as it's project-specific logs not
related to generic test framework

Signed-off-by: Oleksandr Shchirskyi <oleksand.shchirskyi@intel.com>