### PR TITLE
adding tests for by-id core path

### DIFF
--- a/test/functional/tests/cache_ops/test_core_add.py
+++ b/test/functional/tests/cache_ops/test_core_add.py
@@ -1,0 +1,216 @@
+#
+# Copyright(c) 2021 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+#
+
+import os
+from itertools import cycle
+from random import shuffle
+
+import pytest
+
+from api.cas import casadm
+from api.cas.casadm_parser import get_cores
+from core.test_run import TestRun
+from storage_devices.disk import DiskType, DiskTypeSet, DiskTypeLowerThan
+from test_tools.fs_utils import parse_ls_output, ls, remove, readlink
+from test_utils.filesystem.symlink import Symlink
+from test_utils.output import CmdException
+from test_utils.size import Unit, Size
+
+cores_number = 4
+by_id_dir = '/dev/disk/by-id/'
+custom_dir = '/tmp/castle'
+symlink_name = 'dinosaur'
+
+
+@pytest.mark.require_disk("cache", DiskTypeSet([DiskType.optane, DiskType.nand]))
+@pytest.mark.require_disk("core", DiskTypeLowerThan("cache"))
+def test_add_core_path_by_id():
+    """
+    title: Test for adding core with by-id path.
+    description: |
+      Check if OpenCAS accepts by-id path to disks added as cores.
+    pass_criteria:
+      - Cores are added to cache
+      - Cores are added to cache with the same path as given
+    """
+    with TestRun.step("Clearing dmesg"):
+        TestRun.executor.run_expect_success("dmesg -C")
+
+    with TestRun.step("Prepare partitions for cache and for cores."):
+        cache_dev = TestRun.disks['cache']
+        cache_dev.create_partitions([Size(200, Unit.MebiByte)])
+        cache_part = cache_dev.partitions[0]
+        core_dev = TestRun.disks['core']
+        core_dev.create_partitions([Size(400, Unit.MebiByte)] * cores_number)
+
+    with TestRun.step(
+            f"Create symlinks for {core_dev.path} partitions in {by_id_dir} directory."
+    ):
+        for i, partition in enumerate(core_dev.partitions):
+            Symlink.create_symlink(by_id_dir, partition.path)
+
+    with TestRun.step(f"Find symlinks to {core_dev.path} in {by_id_dir}."):
+        links = [
+            Symlink(os.path.join(by_id_dir, item.full_path))       # parse_ls_output returns
+            for item in parse_ls_output(ls(by_id_dir), by_id_dir)  # symlinks without path
+            if isinstance(item, Symlink)
+        ]
+        core_dev_links = [link for link in links if readlink(core_dev.path) in link.get_target()]
+
+    with TestRun.step(f"Select different links to {core_dev.path} partitions."):
+        selected_links = select_links(core_dev_links)
+
+    with TestRun.step("Start cache and add cores"):
+        paths_from_dmesg = []
+        cache = casadm.start_cache(cache_part, force=True)
+        for i in range(cores_number):
+            core_dev.partitions[i].path = selected_links[i].full_path
+            cache.add_core(core_dev.partitions[i])
+            paths_from_dmesg.append(get_added_core_path_from_dmesg())
+
+    with TestRun.step("Check if all cores are added."):
+        added_cores_number = len(get_cores(cache.cache_id))
+        if added_cores_number != cores_number:
+            remove(f"{os.path.join(by_id_dir, symlink_name)}*", True)
+            TestRun.fail(f"Expected {cores_number} cores, got {added_cores_number}!")
+
+    with TestRun.step("Compare paths to cores."):
+        for i in range(cores_number):
+            if paths_from_dmesg[i] != selected_links[i].full_path:
+                TestRun.LOGGER.error(
+                    f"Paths are different and can cause problems!\n"
+                    f"Path passed as an argument to add core: {selected_links[i].full_path}\n"
+                    f"Path currently used in core addition: {paths_from_dmesg[i]}"
+                )
+
+    with TestRun.step("Cleanup test symlinks."):
+        remove(f"{os.path.join(by_id_dir, symlink_name)}*", True)
+
+
+def select_links(links):
+    selected_links = []
+    prev_starts_with = " "
+    prev_ends_with = " "
+    links_cycle = cycle(links)
+
+    while len(selected_links) < cores_number:
+        link = next(links_cycle)
+        if '-part' not in link.name:
+            continue
+        if (
+                link.get_target() not in [sel_link.get_target() for sel_link in selected_links]
+                and not link.name.startswith(prev_starts_with)
+                and not link.name.endswith(prev_ends_with)
+        ):
+            selected_links.append(link)
+            prev_ends_with = link.name.split('-')[-1]
+            prev_starts_with = link.name[:(link.name.index(prev_ends_with) - 1)]
+
+    return selected_links
+
+
+def get_added_core_path_from_dmesg():
+    output = TestRun.executor.run_expect_success("dmesg -c")
+    path_line = [
+        line for line in reversed(output.stdout.splitlines()) if 'as core' in line
+    ][0]
+    path = [item for item in path_line.split() if '/dev/disk/by-id/' in item][0]
+    return path
+
+
+@pytest.mark.require_disk("cache", DiskTypeSet([DiskType.optane, DiskType.nand]))
+@pytest.mark.require_disk("core", DiskTypeLowerThan("cache"))
+def test_add_core_path_not_by_id():
+    """
+    title: Negative test for adding core with non-by-id path.
+    description: |
+      Check if OpenCAS does not accept any other than by-id path to disks added as cores.
+    pass_criteria:
+      - Cores are not added to cache
+    """
+    with TestRun.step("Prepare partitions for cache and for cores."):
+        cache_dev = TestRun.disks['cache']
+        cache_dev.create_partitions([Size(200, Unit.MebiByte)])
+        cache_part = cache_dev.partitions[0]
+        core_dev = TestRun.disks['core']
+        core_dev.create_partitions([Size(400, Unit.MebiByte)] * cores_number)
+
+    with TestRun.step("Start cache."):
+        cache = casadm.start_cache(cache_part, force=True)
+
+    with TestRun.step(f"Create symlinks for {core_dev.path} partitions in {custom_dir} directory."):
+        for i, partition in enumerate(core_dev.partitions):
+            Symlink.create_symlink(custom_dir, readlink(partition.path))
+
+    with TestRun.step(f"Find various symlinks to {core_dev.path}."):
+        core_dev_links = []
+        links = [
+            Symlink(os.path.join(custom_dir, item.full_path))       # parse_ls_output returns
+            for item in parse_ls_output(ls(custom_dir), custom_dir)  # symlinks without path
+            if isinstance(item, Symlink)
+        ]
+
+        for i in range(cores_number):
+            links.append(Symlink(get_by_partuuid_link(core_dev.partitions[i].path)))
+            links.append(Symlink(readlink(core_dev.partitions[i].path)))
+            core_dev_links.extend([
+                link for link in links if readlink(core_dev.partitions[i].path) in link.get_target()
+            ])
+
+    with TestRun.step(f"Select different links to {core_dev.path} partitions."):
+        selected_links = select_random_links(core_dev_links)
+
+    with TestRun.step(f"Try to add {cores_number} cores with non-by-id path."):
+        for i in range(cores_number):
+            core_dev.partitions[i].path = selected_links[i].full_path
+            try:
+                cache.add_core(core_dev.partitions[i])
+                TestRun.fail(f"Core {core_dev.path} is added!")
+            except CmdException:
+                pass
+        TestRun.LOGGER.info("Cannot add cores as expected.")
+
+    with TestRun.step("Check if cores are not added."):
+        added_cores_number = len(get_cores(cache.cache_id))
+        if added_cores_number > 0:
+            remove(f"{os.path.join(custom_dir, symlink_name)}*", True)
+            TestRun.fail(f"Expected 0 cores, got {added_cores_number}!")
+
+    with TestRun.step("Cleanup test symlinks."):
+        remove(f"{os.path.join(custom_dir, symlink_name)}*", True)
+
+
+def get_by_partuuid_link(path):
+    output = TestRun.executor.run(f"blkid {path}")
+    if "PARTUUID" not in output.stdout:
+        return path
+
+    uuid = output.stdout.split()[-1]
+    start = uuid.index('"')
+    end = uuid.index('"', start + 1)
+    uuid = uuid[start + 1:end]
+
+    return f"/dev/disk/by-partuuid/{uuid}"
+
+
+def select_random_links(links):
+    shuffle(links)
+    selected_links = []
+    prev_ends_with = " "
+    links_cycle = cycle(links)
+
+    while len(selected_links) < cores_number:
+        link = next(links_cycle)
+        target = link.get_target()
+        if 'p' not in target:
+            continue
+        if (
+                target not in [sel_link.get_target() for sel_link in selected_links]
+                and not target.endswith(prev_ends_with)
+        ):
+            selected_links.append(link)
+            prev_ends_with = target.split('p')[-1]
+
+    return selected_links

--- a/test/functional/tests/initialize/test_startup_init_config.py
+++ b/test/functional/tests/initialize/test_startup_init_config.py
@@ -2,24 +2,33 @@
 # Copyright(c) 2019-2021 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 #
+import os
+from itertools import cycle
+from time import sleep
 
 import pytest
 
 from api.cas import casadm, casctl, casadm_parser
-from api.cas.casadm_parser import get_caches, get_cores
 from api.cas.cache_config import CacheMode
+from api.cas.casadm import list_caches
+from api.cas.casadm_parser import get_caches, get_cores, get_cas_devices_dict
+from api.cas.cli_messages import check_stdout_msg, no_caches_running
 from api.cas.init_config import InitConfig
 from core.test_run import TestRun
 from storage_devices.disk import DiskType, DiskTypeSet, DiskTypeLowerThan
-from test_utils.filesystem.file import File
-from test_tools.disk_utils import Filesystem
-from test_utils import fstab
 from test_tools.dd import Dd
+from test_tools.disk_utils import Filesystem
+from test_tools.fs_utils import parse_ls_output, readlink, ls
+from test_utils import fstab
+from test_utils.filesystem.file import File
+from test_utils.filesystem.symlink import Symlink
+from test_utils.os_utils import drop_caches, sync
 from test_utils.size import Unit, Size
-
 
 mountpoint = "/mnt"
 filepath = f"{mountpoint}/file"
+cores_number = 4
+by_id_dir = '/dev/disk/by-id/'
 
 
 @pytest.mark.os_dependent
@@ -170,3 +179,166 @@ def validate_cache(cache_mode):
             f"Cache started in wrong mode!\n"
             f"Should start in {cache_mode}, but started in {current_mode} mode."
         )
+
+
+@pytest.mark.remote_only
+@pytest.mark.require_disk("cache", DiskTypeSet([DiskType.optane, DiskType.nand]))
+@pytest.mark.require_disk("core", DiskTypeLowerThan("cache"))
+@pytest.mark.parametrizex("cache_mode", CacheMode)
+@pytest.mark.parametrizex("reboot_type", ["soft", "hard"])
+def test_cas_startup_core_path_by_id(cache_mode, reboot_type):
+    """
+    title: Test for CAS startup when cores are set in config with wrong by-id path.
+    description: |
+      Start cache, add to config different links to devices that make up the cache
+      and check if cache start fails after reboot. Clear cache metadata before reboot.
+    pass_criteria:
+      - System does not crash
+      - Cache is running after startup
+      - Cores are detached after startup
+    """
+    with TestRun.step("Clearing dmesg"):
+        TestRun.executor.run_expect_success("dmesg -C")
+
+    with TestRun.step("Prepare partitions for cache and for cores."):
+        cache_dev = TestRun.disks['cache']
+        cache_dev.create_partitions([Size(200, Unit.MebiByte)])
+        cache_part = cache_dev.partitions[0]
+        core_dev = TestRun.disks['core']
+        core_dev.create_partitions([Size(400, Unit.MebiByte)] * cores_number)
+
+    with TestRun.step(f"Find symlinks to {core_dev.path} in {by_id_dir}."):
+        links = [
+            Symlink(os.path.join(by_id_dir, item.full_path))       # parse_ls_output returns
+            for item in parse_ls_output(ls(by_id_dir), by_id_dir)  # symlinks without path
+            if isinstance(item, Symlink)
+        ]
+        core_dev_links = [link for link in links if readlink(core_dev.path) in link.get_target()]
+
+    with TestRun.step(f"Select different links to {core_dev.path} partitions."):
+        selected_links = select_links(core_dev_links)
+
+    with TestRun.step("Start cache and add cores."):
+        cores = []
+        cache = casadm.start_cache(cache_part, cache_mode, force=True)
+        for i in range(cores_number):
+            core_dev.partitions[i].path = selected_links[i].full_path
+            cores.append(cache.add_core(core_dev.partitions[i]))
+
+    with TestRun.step("Create opencas.conf."):
+        create_init_config(cache, cores, [link.full_path for link in selected_links])
+        drop_caches()
+        sync()
+
+    with TestRun.step("Stop cache and clear metadata before reboot."):
+        cache.stop()
+        casadm.zero_metadata(cache_part)
+
+    with TestRun.step("Reset platform."):
+        if reboot_type == "soft":
+            TestRun.executor.reboot()
+        else:           # wait few seconds to simulate power failure during normal system run
+            sleep(5)    # not when configuring Open CAS
+            power_control = TestRun.plugin_manager.get_plugin('power_control')
+            power_control.power_cycle()
+
+    with TestRun.step("Check if all cores are detached."):
+        listed_cores = get_cas_devices_dict().get("core_pool")
+        listed_cores_number = len(listed_cores)
+        if listed_cores_number != cores_number:
+            TestRun.fail(f"Expected {cores_number} cores, got {listed_cores_number}!")
+
+        for core in listed_cores:
+            if core.get("status") != "Detached":
+                TestRun.fail(f"Core {core.get('device')} isn't detached as expected.")
+
+
+@pytest.mark.remote_only
+@pytest.mark.require_disk("cache", DiskTypeSet([DiskType.optane, DiskType.nand]))
+@pytest.mark.require_disk("core", DiskTypeLowerThan("cache"))
+@pytest.mark.parametrizex("cache_mode", CacheMode)
+@pytest.mark.parametrizex("reboot_type", ["soft", "hard"])
+def test_cas_startup_core_path_not_by_id(cache_mode, reboot_type):
+    """
+    title: Negative test for CAS startup when cores are set in config with short path.
+    description: |
+      Start cache, add to config short path (/dev/sdX) to devices that make up the
+      cache and check if cache start fails after reboot. Clear cache metadata before reboot.
+    pass_criteria:
+      - System does not crash
+      - Cache is not running after startup
+      - No cores after startup
+    """
+    with TestRun.step("Clearing dmesg"):
+        TestRun.executor.run_expect_success("dmesg -C")
+
+    with TestRun.step("Prepare partitions for cache and for cores."):
+        cache_dev = TestRun.disks['cache']
+        cache_dev.create_partitions([Size(200, Unit.MebiByte)])
+        cache_part = cache_dev.partitions[0]
+        core_dev = TestRun.disks['core']
+        core_dev.create_partitions([Size(400, Unit.MebiByte)] * cores_number)
+
+    with TestRun.step("Start cache and add cores."):
+        cores = []
+        cache = casadm.start_cache(cache_part, cache_mode, force=True)
+        for i in range(cores_number):
+            cores.append(cache.add_core(core_dev.partitions[i]))
+
+    with TestRun.step("Create opencas.conf."):
+        create_init_config(cache, cores, [readlink(part.path) for part in core_dev.partitions])
+        drop_caches()
+        sync()
+
+    with TestRun.step("Stop cache and clear metadata before reboot."):
+        cache.stop()
+        casadm.zero_metadata(cache_part)
+
+    with TestRun.step("Reset platform."):
+        if reboot_type == "soft":
+            TestRun.executor.reboot()
+        else:           # wait few seconds to simulate power failure during normal system run
+            sleep(5)    # not when configuring Open CAS
+            power_control = TestRun.plugin_manager.get_plugin('power_control')
+            power_control.power_cycle()
+
+    with TestRun.step("Check if cache is not running."):
+        check_stdout_msg(list_caches(), no_caches_running)
+
+
+def select_links(links):
+    selected_links = []
+    prev_starts_with = " "
+    prev_ends_with = " "
+    links_cycle = cycle(links)
+
+    while len(selected_links) < cores_number:
+        link = next(links_cycle)
+        if '-part' not in link.name:
+            continue
+        if (
+                link.get_target() not in [sel_link.get_target() for sel_link in selected_links]
+                and not link.name.startswith(prev_starts_with)
+                and not link.name.endswith(prev_ends_with)
+        ):
+            selected_links.append(link)
+            prev_ends_with = link.name.split('-')[-1]
+            prev_starts_with = link.name[:(link.name.index(prev_ends_with) - 1)]
+
+    return selected_links
+
+
+def create_init_config(cache, cores, paths):
+    init_conf = InitConfig()
+
+    def _add_core(core, path):
+        params = [str(cache.cache_id), str(core.core_id), path, "lazy_startup=true"]
+        init_conf.core_config_lines.append('\t'.join(params))
+
+    init_conf.add_cache(
+        cache.cache_id, cache.cache_device, cache.get_cache_mode(), "lazy_startup=true"
+    )
+    for i in range(cores_number):
+        _add_core(cores[i], paths[i])
+    init_conf.save_config_file()
+    return init_conf


### PR DESCRIPTION
Original review: https://github.com/Open-CAS/open-cas-linux/pull/539 

This PR needs functionality from: https://github.com/Open-CAS/test-framework/pull/259

Signed-off-by: Karolina Rogowska <karolina.rogowska@intel.com>