### PR TITLE
[v21.6.1] Fix cache_priv deallocation

### DIFF
--- a/modules/cas_cache/layer_cache_management.c
+++ b/modules/cas_cache/layer_cache_management.c
@@ -1989,7 +1989,7 @@ static int _cache_mngt_cache_priv_init(ocf_cache_t cache)
 	cache_priv->stop_context =
 		env_malloc(sizeof(*cache_priv->stop_context), GFP_KERNEL);
 	if (!cache_priv->stop_context) {
-		kfree(cache_priv);
+		vfree(cache_priv);
 		return -ENOMEM;
 	}
 


### PR DESCRIPTION
Since cache_priv is allocated with vmalloc() it should be deallocated
with vfree().

Signed-off-by: Robert Baldyga <robert.baldyga@intel.com>