### PR TITLE
[v21.6.1] Fix API incompatibility detection in configure script

### DIFF
--- a/configure.d/Makefile
+++ b/configure.d/Makefile
@@ -8,6 +8,14 @@ obj-m += test_mod.o
 
 MAKE_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
+check_cflag=$(shell echo "" | \
+	gcc -c -xc ${1} -o /dev/null - 2>/dev/null; \
+	if [ $$? -eq 0 ]; then echo 1; else echo 0; fi; )
+
+ifeq ($(call check_cflag,-Werror=int-conversion), 1)
+EXTRA_CFLAGS += -Werror=int-conversion
+endif
+
 all:
 	make -C $(KERNEL_DIR) M=$(MAKE_DIR) modules
 clean:


### PR DESCRIPTION
Convert warning about int to pointer detection into an error.

Signed-off-by: Robert Baldyga <robert.baldyga@intel.com>