### PR TITLE
[v21.6.1]Include proper header

### DIFF
--- a/configure.d/1_bd_first_part.conf
+++ b/configure.d/1_bd_first_part.conf
@@ -9,7 +9,7 @@
 check() {
 	cur_name=$(basename $2)
 	config_file_path=$1
-	if compile_module $cur_name "struct block_device *bd; bd = disk_part_iter_next(NULL);" "linux/blk_types.h"
+	if compile_module $cur_name "struct block_device *bd; bd = disk_part_iter_next(NULL);" "linux/genhd.h" "linux/genhd.h"
 	then
 		echo $cur_name "1" >> $config_file_path
 	elif compile_module $cur_name "struct hd_struct *hd; hd = disk_part_iter_next(NULL);" "linux/genhd.h"


### PR DESCRIPTION
`disk_part_iter_next()` is defined within `linux/genhd.h`

Signed-off-by: Michal Mielewczyk <michal.mielewczyk@intel.com>