### PR TITLE
Enable passing cleaning policy to start-cache cmd

### DIFF
--- a/casadm/cas_lib.c
+++ b/casadm/cas_lib.c
@@ -963,7 +963,7 @@ static void check_cache_scheduler(const char *cache_device, const char *elv_name
 
 int start_cache(uint16_t cache_id, unsigned int cache_init,
 		const char *cache_device, ocf_cache_mode_t cache_mode,
-		ocf_cache_line_size_t line_size, int force)
+		ocf_cache_line_size_t line_size, int force, ocf_cleaning_t clean_pol)
 {
 	int fd = 0;
 	struct kcas_start_cache cmd;
@@ -1012,6 +1012,7 @@ int start_cache(uint16_t cache_id, unsigned int cache_init,
 	}
 	cmd.caching_mode = cache_mode;
 	cmd.line_size = line_size;
+	cmd.cleaning_policy_type = clean_pol;
 	cmd.force = (uint8_t)force;
 
 	if (run_ioctl_interruptible_retry(fd, KCAS_IOCTL_START_CACHE, &cmd,

--- a/casadm/cas_lib.h
+++ b/casadm/cas_lib.h
@@ -112,7 +112,7 @@ void metadata_memory_footprint(uint64_t size, float *footprint, const char **uni
 
 int start_cache(uint16_t cache_id, unsigned int cache_init,
 		const char *cache_device, ocf_cache_mode_t cache_mode,
-		ocf_cache_line_size_t line_size, int force);
+		ocf_cache_line_size_t line_size, int force, ocf_cleaning_t clean_pol);
 int stop_cache(uint16_t cache_id, int flush);
 
 #ifdef WI_AVAILABLE

--- a/modules/cas_cache/layer_cache_management.c
+++ b/modules/cas_cache/layer_cache_management.c
@@ -1861,6 +1861,7 @@ int cache_mngt_prepare_cache_cfg(struct ocf_mngt_cache_config *cfg,
 	cfg->cache_mode = cmd->caching_mode;
 	cfg->cache_line_size = cmd->line_size;
 	cfg->promotion_policy = ocf_promotion_default;
+	cfg->cleaning_policy = cmd->cleaning_policy_type;
 	cfg->cache_line_size = cmd->line_size;
 	cfg->pt_unaligned_io = !unaligned_io;
 	cfg->use_submit_io_fast = !use_io_scheduler;

--- a/modules/include/cas_ioctl_codes.h
+++ b/modules/include/cas_ioctl_codes.h
@@ -71,6 +71,8 @@ struct kcas_start_cache {
 	 */
 	ocf_cache_line_size_t line_size;
 
+	ocf_cleaning_t cleaning_policy_type;
+
 	uint8_t force; /**< should force option be used? */
 
 	uint64_t min_free_ram; /**< Minimum free RAM memory for cache metadata */


### PR DESCRIPTION
Since initializing cleaning policy was moved from standby-activate to
standby-start (to fulfill activation time requirements) the cleaning policy has
to known during starting cache

Signed-off-by: Michal Mielewczyk <michal.mielewczyk@intel.com>