### PR TITLE
Add 'failover' to smoke-test's dictionary

### DIFF
--- a/test/smoke_test/cas_ex.en.pws
+++ b/test/smoke_test/cas_ex.en.pws
@@ -33,6 +33,7 @@ conf
 config
 csv
 dev
+failover
 io
 kibibytes
 lru


### PR DESCRIPTION
New functionalities introduced --failover-... flags, so it needed to be added to aspell dictionary for smoke tests.

Signed-off-by: Rafal Stefanowski <rafal.stefanowski@intel.com>