### PR TITLE
License change to be approved by contributors

### DIFF
--- a/configure.d/1_bdev_lookup.conf
+++ b/configure.d/1_bdev_lookup.conf
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # Copyright(c) 2012-2021 Intel Corporation
-# SPDX-License-Identifier: BSD-3-Clause-Clear
+# SPDX-License-Identifier: BSD-3-Clause
 #
 
 . $(dirname $3)/conf_framework

--- a/configure.d/conf_framework
+++ b/configure.d/conf_framework
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # Copyright(c) 2012-2021 Intel Corporation
-# SPDX-License-Identifier: BSD-3-Clause-Clear
+# SPDX-License-Identifier: BSD-3-Clause
 #
 
 SCRIPTPATH=`dirname $0`

--- a/utils/casctl
+++ b/utils/casctl
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 #
 # Copyright(c) 2012-2021 Intel Corporation
-# SPDX-License-Identifier: BSD-3-Clause-Clear
+# SPDX-License-Identifier: BSD-3-Clause
 #
 
 import argparse

--- a/utils/open-cas.service
+++ b/utils/open-cas.service
@@ -1,6 +1,6 @@
 #
 # Copyright(c) 2019-2021 Intel Corporation
-# SPDX-License-Identifier: BSD-3-Clause-Clear
+# SPDX-License-Identifier: BSD-3-Clause
 #
 
 [Unit]


### PR DESCRIPTION
Open CAS and other projects in the Open CAS repo were always intended to be released under the OSI-approved BSD 3-Clause License (SPDX-License-Identifier: BSD-3-Clause), however it was recently discovered that a non-OSI-approved license, the similarly-named BSD 3-Clause “Clear” License (SPDX-License-Identifier: BSD-3-Clause-Clear) was incorrectly applied to many files in these repositories.
 
We are in the process of correcting the error and are asking all contributors to confirm that their contributions were intended to be made under the OSI-approved BSD 3-Clause License. To confirm, please reply to this message and state that your contributions were made under the BSD 3-Clause License. Thank you for your assistance and apologies for any inconvenience.

@anatol @lausaa @liuhongtong can you confirm the license change for your contributions?

Signed-off-by: Rafal Stefanowski <rafal.stefanowski@intel.com>