### PR TITLE
Add multi-arch package build support

### DIFF
--- a/tools/pckgen
+++ b/tools/pckgen
@@ -68,6 +68,7 @@ print_help() {
     echo "  dsc                             generate DSC (source DEB) package"
     echo
     echo "Options:"
+    echo "  -a, --arch <ARCH>               target platform architecture for packages"
     echo "  -o, --output-dir <DIR>          put all created files in the given directory;"
     echo "                                  default: 'SOURCES_PATH/packages/'"
     echo "  -d, --debug                     create all debug files and packages as well"
@@ -366,7 +367,7 @@ generate_rpm() {
 
     if [ ! "$GENERATE_SRPM" ] && [ "$GENERATE_RPM" ]; then
         echo "--- Building binary RPM packages"
-        (HOME="$TEMP_DIR"; rpmbuild -bb "$RPM_SPECS_DIR/$CAS_NAME.spec")
+        (HOME="$TEMP_DIR"; rpmbuild -bb --target "$ARCH" "$RPM_SPECS_DIR/$CAS_NAME.spec")
         if [ $? -ne 0 ]; then
             error "couldn't create RPM packages"
         fi
@@ -382,7 +383,7 @@ generate_rpm() {
     fi
     if [ "$GENERATE_SRPM" ] && [ "$GENERATE_RPM" ]; then
         echo "--- Building source and binary RPM packages"
-        (HOME="$TEMP_DIR"; rpmbuild -ba "$RPM_SPECS_DIR/$CAS_NAME.spec")
+        (HOME="$TEMP_DIR"; rpmbuild -ba --target "$ARCH" "$RPM_SPECS_DIR/$CAS_NAME.spec")
         if [ $? -ne 0 ]; then
             error "couldn't create RPM packages"
         fi
@@ -407,7 +408,7 @@ generate_deb() {
 
     if [ ! "$GENERATE_DSC" ] && [ "$GENERATE_DEB" ]; then
         echo "--- Building binary DEB packages"
-        (cd "$DEB_SOURCES_DIR" && debuild -us -uc -b)
+        (cd "$DEB_SOURCES_DIR" && debuild -us -uc -b --host-type "$ARCH-linux-gnu")
         if [ $? -ne 0 ]; then
             error "couldn't create DEB packages"
         fi
@@ -425,7 +426,7 @@ generate_deb() {
     fi
     if [ "$GENERATE_DSC" ] && [ "$GENERATE_DEB" ]; then
         echo "--- Building DEB and DSC (source DEB) packages"
-        (cd "$DEB_SOURCES_DIR" && debuild -us -uc -F)
+        (cd "$DEB_SOURCES_DIR" && debuild -us -uc -F --host-type "$ARCH-linux-gnu")
         if [ $? -ne 0 ]; then
             error "couldn't create DEB and DSC packages"
         fi
@@ -466,6 +467,10 @@ while (( $# )); do
             ;;
         dsc)
             GENERATE_DSC="generate_dsc"
+            ;;
+        --arch|-a)
+            ARCH="$2"
+            shift
             ;;
         --output-dir|-o)
             OUTPUT_DIR="$2"

--- a/tools/pckgen.d/deb/debian/changelog
+++ b/tools/pckgen.d/deb/debian/changelog
@@ -8,7 +8,7 @@ open-cas-linux (20.03.3.0303-1) trusty; urgency=medium
 
   * Update dependencies
 
- -- Michal Mielewczyk <michal.mielewczyk@intel.com> Mon, 22 Nov 2021 13:02:30 +0100
+ -- Michal Mielewczyk <michal.mielewczyk@intel.com>  Mon, 22 Nov 2021 13:02:30 +0100
 
 open-cas-linux (20.03.3.0303-1) trusty; urgency=medium
 

--- a/tools/pckgen.d/deb/debian/control
+++ b/tools/pckgen.d/deb/debian/control
@@ -8,7 +8,7 @@ Homepage: <CAS_HOMEPAGE>
 Vcs-Git: <CAS_GIT>
 
 Package: <CAS_NAME>
-Architecture: amd64
+Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, python3, python3-packaging, python3-yaml,
  <CAS_NAME>-modules (= <CAS_VERSION>-1)
 Description: Open Cache Acceleration Software
@@ -20,7 +20,7 @@ Description: Open Cache Acceleration Software
  running cache instances (no kernel modules).
 
 Package: <CAS_NAME>-modules
-Architecture: amd64
+Architecture: any
 Depends: ${misc:Depends}, debhelper (>= 9), dkms
 Description: Open Cache Acceleration Software kernel modules (${kver})
  Open Cache Acceleration Software (Open CAS) is an open source project


### PR DESCRIPTION
- do not restrain package build to just one architecture
  and allow user to create packages outside of x86_64
- add pckgen option to specify different architecture
  to build packages for, instead of the current one

Signed-off-by: Rafal Stefanowski <rafal.stefanowski@intel.com>