### PR TITLE
Fix kernel __vmalloc() check

### DIFF
--- a/configure.d/1_vmalloc.conf
+++ b/configure.d/1_vmalloc.conf
@@ -12,7 +12,7 @@ check() {
     if compile_module $cur_name "__vmalloc(0, 0);" "linux/vmalloc.h"
     then
         echo $cur_name "1" >> $config_file_path
-    elif compile_module $cur_name "struct pgprot x; __vmalloc(0, 0, x);" "linux/vmalloc.h"
+    elif compile_module $cur_name "pgprot_t x; __vmalloc(0, 0, x);" "linux/vmalloc.h"
     then
         echo $cur_name "2" >> $config_file_path
     else


### PR DESCRIPTION
Use dedicated 'pgprot_t' type instead of 'struct pgprot'
which is only defined for x86 architecture.

Signed-off-by: Rafal Stefanowski <rafal.stefanowski@intel.com>