### PR TITLE
Fix _cas_cleaner_thread stuck when cleaning not performed

### DIFF
--- a/modules/cas_cache/threads.c
+++ b/modules/cas_cache/threads.c
@@ -93,8 +93,8 @@ static int _cas_cleaner_thread(void *data)
 
 		atomic_set(&info->kicked, 0);
 		init_completion(&info->sync_compl);
-		ocf_cleaner_run(c, cache_priv->io_queues[smp_processor_id()]);
-		wait_for_completion(&info->sync_compl);
+		if (ocf_cleaner_run(c, cache_priv->io_queues[smp_processor_id()]))
+			wait_for_completion(&info->sync_compl);
 
 		/*
 		 * In case of nop cleaning policy we don't want to perform cleaning


### PR DESCRIPTION
when ocf_cleaner_run can't perform cleaning for some reasons,
it will not call _cas_cleaner_complete to complete info->sync_compl,
_cas_cleaner_thread will stuck for waiting this completion.

[ 1694.477896] INFO: task cas_cl_cache1:1909 blocked for more than 120 seconds.
[ 1694.479252]       Tainted: G           OE     4.19.90+pitrix1 Open-CAS#1
[ 1694.480453] "echo 0 > /proc/sys/kernel/hung_task_timeout_secs" disables this message.
[ 1694.482023] cas_cl_cache1   D    0  1909      2 0x00000028
[ 1694.482027] Call trace:
[ 1694.482033]  __switch_to+0xf0/0x150
[ 1694.482044]  __schedule+0x2ac/0x718
[ 1694.482050]  schedule+0x30/0xe8
[ 1694.482055]  schedule_timeout+0x244/0x388
[ 1694.482064]  wait_for_common+0x180/0x280
[ 1694.482068]  wait_for_completion+0x28/0x38
[ 1694.482103]  _cas_cleaner_thread+0xec/0x208 [cas_cache]
[ 1694.482107]  kthread+0x134/0x138
[ 1694.482109]  ret_from_fork+0x10/0x18

Signed-off-by: Sun Feng <loyou85@gmail.com>