### PR TITLE
Check __vmalloc support with pgprot_t

### DIFF
--- a/configure.d/1_vmalloc.conf
+++ b/configure.d/1_vmalloc.conf
@@ -12,7 +12,7 @@ check() {
     if compile_module $cur_name "__vmalloc(0, 0);" "linux/vmalloc.h"
     then
         echo $cur_name "1" >> $config_file_path
-    elif compile_module $cur_name "struct pgprot x; __vmalloc(0, 0, x);" "linux/vmalloc.h"
+    elif compile_module $cur_name "pgprot_t x; __vmalloc(0, 0, x);" "linux/vmalloc.h"
     then
         echo $cur_name "2" >> $config_file_path
     else


### PR DESCRIPTION
__vmalloc is defined with:

void *__vmalloc(unsigned long size, gfp_t gfp_mask, pgprot_t prot)

it will break ./configure on arm64 with following errors:

  # ./configure
  Preparing configuration
  ERROR! Following steps failed while preparing config:
  1_vmalloc.conf
  Makefile:5: recipe for target 'build' failed
  make: *** [build] Error 1
  make: Leaving directory '/usr/local/src/open-cas-linux-buildonly/open-cas-linux'

Signed-off-by: Sun Feng <loyou85@gmail.com>