### PR TITLE
Fix for casadm output when listing detached cache

### DIFF
--- a/casadm/cas_lib.h
+++ b/casadm/cas_lib.h
@@ -49,6 +49,7 @@ struct cache_device {
 	int flushed;
 	unsigned size;
 	int core_count;
+	bool standby_detached;
 	struct core_device cores[];
 };
 
@@ -87,7 +88,7 @@ enum output_format_t {
 const char *cleaning_policy_to_name(uint8_t policy);
 const char *promotion_policy_to_name(uint8_t policy);
 const char *cache_mode_to_name(uint8_t cache_mode);
-const char *get_cache_state_name(int cache_state);
+const char *get_cache_state_name(int cache_state, bool detached);
 const char *get_core_state_name(int core_state);
 const char *seq_cutoff_policy_to_name(uint8_t seq_cutoff_policy);
 

--- a/casadm/statistics_model.c
+++ b/casadm/statistics_model.c
@@ -589,7 +589,7 @@ int cache_stats_conf(int ctrl_fd, const struct kcas_cache_info *cache_info,
 			      "Flushing", flush_progress);
 	} else {
 		print_kv_pair(outfile, "Status", "%s",
-				get_cache_state_name(cache_info->info.state));
+				get_cache_state_name(cache_info->info.state, cache_info->info.standby_detached));
 	}
 
 	return SUCCESS;


### PR DESCRIPTION
Fix for issue #1020 - make casadm produce a meaningful output when
listing a detached cache

Signed-off-by: Krzysztof Majzerowicz-Jaszcz <krzysztof.majzerowicz-jaszcz@intel.com>