### PR TITLE
Remove edition date from file headers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright(c) 2019-2021 Intel Corporation
+Copyright(c) 2019 Intel Corporation
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/casadm/Makefile
+++ b/casadm/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/casadm/argp.c
+++ b/casadm/argp.c
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/casadm/argp.h
+++ b/casadm/argp.h
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/casadm/cas_lib.c
+++ b/casadm/cas_lib.c
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/casadm/cas_lib.h
+++ b/casadm/cas_lib.h
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/casadm/cas_lib_utils.c
+++ b/casadm/cas_lib_utils.c
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/casadm/cas_lib_utils.h
+++ b/casadm/cas_lib_utils.h
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/casadm/cas_main.c
+++ b/casadm/cas_main.c
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/casadm/casadm.8
+++ b/casadm/casadm.8
@@ -7,7 +7,7 @@ casadm \- create, and manage Open CAS instances
 \fBcasadm\fR <command> [options...]
 
 .SH COPYRIGHT
-Copyright(c) 2012-2021 by the Intel Corporation.
+Copyright(c) 2012 Intel Corporation.
 
 .SH DESCRIPTION
 Open Cache Acceleration Software (CAS) accelerates Linux applications by caching

--- a/casadm/csvparse.c
+++ b/casadm/csvparse.c
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/casadm/csvparse.h
+++ b/casadm/csvparse.h
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/casadm/extended_err_msg.c
+++ b/casadm/extended_err_msg.c
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/casadm/extended_err_msg.h
+++ b/casadm/extended_err_msg.h
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/casadm/intvector.c
+++ b/casadm/intvector.c
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/casadm/intvector.h
+++ b/casadm/intvector.h
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/casadm/ocf_env.h
+++ b/casadm/ocf_env.h
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/casadm/ocf_env_headers.h
+++ b/casadm/ocf_env_headers.h
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/casadm/psort.c
+++ b/casadm/psort.c
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 #include <unistd.h>

--- a/casadm/psort.h
+++ b/casadm/psort.h
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/casadm/statistics_model.c
+++ b/casadm/statistics_model.c
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/casadm/statistics_view.c
+++ b/casadm/statistics_view.c
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/casadm/statistics_view.h
+++ b/casadm/statistics_view.h
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/casadm/statistics_view_csv.c
+++ b/casadm/statistics_view_csv.c
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/casadm/statistics_view_csv.h
+++ b/casadm/statistics_view_csv.h
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/casadm/statistics_view_raw_csv.c
+++ b/casadm/statistics_view_raw_csv.c
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/casadm/statistics_view_raw_csv.h
+++ b/casadm/statistics_view_raw_csv.h
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/casadm/statistics_view_structs.h
+++ b/casadm/statistics_view_structs.h
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/casadm/statistics_view_text.c
+++ b/casadm/statistics_view_text.c
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/casadm/statistics_view_text.h
+++ b/casadm/statistics_view_text.h
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/casadm/table.c
+++ b/casadm/table.c
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 #include <stdlib.h>

--- a/casadm/table.h
+++ b/casadm/table.h
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/casadm/vt100codes.h
+++ b/casadm/vt100codes.h
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/configure
+++ b/configure
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/configure.d/1_append_bio.conf
+++ b/configure.d/1_append_bio.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/configure.d/1_bd_first_part.conf
+++ b/configure.d/1_bd_first_part.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/configure.d/1_bdev_lookup.conf
+++ b/configure.d/1_bdev_lookup.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/configure.d/1_bdev_nr_sectors.conf
+++ b/configure.d/1_bdev_nr_sectors.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/configure.d/1_bdev_whole.conf
+++ b/configure.d/1_bdev_whole.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/configure.d/1_bdget_disk.conf
+++ b/configure.d/1_bdget_disk.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/configure.d/1_bio_clone.conf
+++ b/configure.d/1_bio_clone.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/configure.d/1_bio_dev.conf
+++ b/configure.d/1_bio_dev.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/configure.d/1_bio_discard.conf
+++ b/configure.d/1_bio_discard.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/configure.d/1_bio_err.conf
+++ b/configure.d/1_bio_err.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/configure.d/1_bio_flags.conf
+++ b/configure.d/1_bio_flags.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/configure.d/1_bio_gendisk.conf
+++ b/configure.d/1_bio_gendisk.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/configure.d/1_bio_iter.conf
+++ b/configure.d/1_bio_iter.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/configure.d/1_bio_split.conf
+++ b/configure.d/1_bio_split.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/configure.d/1_biovec.conf
+++ b/configure.d/1_biovec.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/configure.d/1_blk_end_req.conf
+++ b/configure.d/1_blk_end_req.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/configure.d/1_blk_mq.conf
+++ b/configure.d/1_blk_mq.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/configure.d/1_blk_status.conf
+++ b/configure.d/1_blk_status.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/configure.d/1_block_pc.conf
+++ b/configure.d/1_block_pc.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/configure.d/1_deamonize.conf
+++ b/configure.d/1_deamonize.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/configure.d/1_dentry.conf
+++ b/configure.d/1_dentry.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/configure.d/1_discard_zeros.conf
+++ b/configure.d/1_discard_zeros.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/configure.d/1_err_no_to_blk_sts.conf
+++ b/configure.d/1_err_no_to_blk_sts.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/configure.d/1_flush_flag.conf
+++ b/configure.d/1_flush_flag.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/configure.d/1_global_page_state.conf
+++ b/configure.d/1_global_page_state.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/configure.d/1_hlist.conf
+++ b/configure.d/1_hlist.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/configure.d/1_inode.conf
+++ b/configure.d/1_inode.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/configure.d/1_kallsyms_on_each_symbol.conf
+++ b/configure.d/1_kallsyms_on_each_symbol.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/configure.d/1_make_request.conf
+++ b/configure.d/1_make_request.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/configure.d/1_mq_flags.conf
+++ b/configure.d/1_mq_flags.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/configure.d/1_munmap.conf
+++ b/configure.d/1_munmap.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/configure.d/1_queue_bounce.conf
+++ b/configure.d/1_queue_bounce.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/configure.d/1_queue_chunk_sectors.conf
+++ b/configure.d/1_queue_chunk_sectors.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/configure.d/1_queue_flag_set.conf
+++ b/configure.d/1_queue_flag_set.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/configure.d/1_queue_limits.conf
+++ b/configure.d/1_queue_limits.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/configure.d/1_queue_lock.conf
+++ b/configure.d/1_queue_lock.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/configure.d/1_reread_partitions.conf
+++ b/configure.d/1_reread_partitions.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/configure.d/1_set_submit_bio.conf
+++ b/configure.d/1_set_submit_bio.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/configure.d/1_submit_bio.conf
+++ b/configure.d/1_submit_bio.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/configure.d/1_timekeeping.conf
+++ b/configure.d/1_timekeeping.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/configure.d/1_vfs_ioctl.conf
+++ b/configure.d/1_vfs_ioctl.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/configure.d/1_vmalloc.conf
+++ b/configure.d/1_vmalloc.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/configure.d/1_write_flag.conf
+++ b/configure.d/1_write_flag.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/configure.d/1_wtlh.conf
+++ b/configure.d/1_wtlh.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/configure.d/2_bio_barrier.conf
+++ b/configure.d/2_bio_barrier.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/configure.d/2_bio_cmpl.conf
+++ b/configure.d/2_bio_cmpl.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/configure.d/2_generic_acct.conf
+++ b/configure.d/2_generic_acct.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/configure.d/2_make_req.conf
+++ b/configure.d/2_make_req.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/configure.d/2_queue_write.conf
+++ b/configure.d/2_queue_write.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/configure.d/Makefile
+++ b/configure.d/Makefile
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/configure.d/conf_framework
+++ b/configure.d/conf_framework
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/modules/Makefile
+++ b/modules/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 # If $(M) is defined, we've been invoked from the

--- a/modules/cas_cache/Makefile
+++ b/modules/cas_cache/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 include $(M)/config.mk

--- a/modules/cas_cache/cas_cache.h
+++ b/modules/cas_cache/cas_cache.h
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/modules/cas_cache/classifier.c
+++ b/modules/cas_cache/classifier.c
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2019-2021 Intel Corporation
+* Copyright(c) 2019 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/modules/cas_cache/classifier.h
+++ b/modules/cas_cache/classifier.h
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2019-2021 Intel Corporation
+* Copyright(c) 2019 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/modules/cas_cache/classifier_defs.h
+++ b/modules/cas_cache/classifier_defs.h
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2019-2021 Intel Corporation
+* Copyright(c) 2019 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/modules/cas_cache/context.c
+++ b/modules/cas_cache/context.c
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/modules/cas_cache/context.h
+++ b/modules/cas_cache/context.h
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/modules/cas_cache/control.c
+++ b/modules/cas_cache/control.c
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 #include <linux/cdev.h>

--- a/modules/cas_cache/control.h
+++ b/modules/cas_cache/control.h
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 #ifndef __CAS_CONTROL_H__

--- a/modules/cas_cache/layer_cache_management.c
+++ b/modules/cas_cache/layer_cache_management.c
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/modules/cas_cache/layer_cache_management.h
+++ b/modules/cas_cache/layer_cache_management.h
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 #ifndef __LAYER_CACHE_MANAGEMENT_H__

--- a/modules/cas_cache/linux_kernel_version.h
+++ b/modules/cas_cache/linux_kernel_version.h
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/modules/cas_cache/main.c
+++ b/modules/cas_cache/main.c
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/modules/cas_cache/ocf_env.c
+++ b/modules/cas_cache/ocf_env.c
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/modules/cas_cache/ocf_env.h
+++ b/modules/cas_cache/ocf_env.h
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/modules/cas_cache/ocf_env_headers.h
+++ b/modules/cas_cache/ocf_env_headers.h
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/modules/cas_cache/service_ui_ioctl.c
+++ b/modules/cas_cache/service_ui_ioctl.c
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/modules/cas_cache/service_ui_ioctl.h
+++ b/modules/cas_cache/service_ui_ioctl.h
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/modules/cas_cache/threads.c
+++ b/modules/cas_cache/threads.c
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/modules/cas_cache/threads.h
+++ b/modules/cas_cache/threads.h
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/modules/cas_cache/utils/cas_err.h
+++ b/modules/cas_cache/utils/cas_err.h
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/modules/cas_cache/utils/utils_blk.c
+++ b/modules/cas_cache/utils/utils_blk.c
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/modules/cas_cache/utils/utils_blk.h
+++ b/modules/cas_cache/utils/utils_blk.h
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/modules/cas_cache/utils/utils_data.c
+++ b/modules/cas_cache/utils/utils_data.c
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/modules/cas_cache/utils/utils_data.h
+++ b/modules/cas_cache/utils/utils_data.h
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/modules/cas_cache/utils/utils_gc.c
+++ b/modules/cas_cache/utils/utils_gc.c
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/modules/cas_cache/utils/utils_gc.h
+++ b/modules/cas_cache/utils/utils_gc.h
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/modules/cas_cache/utils/utils_mpool.c
+++ b/modules/cas_cache/utils/utils_mpool.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/modules/cas_cache/utils/utils_mpool.h
+++ b/modules/cas_cache/utils/utils_mpool.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2012-2021 Intel Corporation
+ * Copyright(c) 2012 Intel Corporation
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/modules/cas_cache/utils/utils_rpool.c
+++ b/modules/cas_cache/utils/utils_rpool.c
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/modules/cas_cache/utils/utils_rpool.h
+++ b/modules/cas_cache/utils/utils_rpool.h
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/modules/cas_cache/volume/obj_blk.h
+++ b/modules/cas_cache/volume/obj_blk.h
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/modules/cas_cache/volume/vol_blk_utils.c
+++ b/modules/cas_cache/volume/vol_blk_utils.c
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/modules/cas_cache/volume/vol_blk_utils.h
+++ b/modules/cas_cache/volume/vol_blk_utils.h
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/modules/cas_cache/volume/vol_block_dev_bottom.c
+++ b/modules/cas_cache/volume/vol_block_dev_bottom.c
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/modules/cas_cache/volume/vol_block_dev_bottom.h
+++ b/modules/cas_cache/volume/vol_block_dev_bottom.h
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/modules/cas_cache/volume/vol_block_dev_top.c
+++ b/modules/cas_cache/volume/vol_block_dev_top.c
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/modules/cas_cache/volume/vol_block_dev_top.h
+++ b/modules/cas_cache/volume/vol_block_dev_top.h
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/modules/cas_disk/Makefile
+++ b/modules/cas_disk/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 include $(M)/config.mk

--- a/modules/cas_disk/cas_disk.h
+++ b/modules/cas_disk/cas_disk.h
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 #ifndef __CASDISK_H__

--- a/modules/cas_disk/cas_disk_defs.h
+++ b/modules/cas_disk/cas_disk_defs.h
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 #ifndef __CASDISK_DEFS_H__

--- a/modules/cas_disk/debug.h
+++ b/modules/cas_disk/debug.h
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 #ifndef __CASDISK_DEBUG_H__

--- a/modules/cas_disk/disk.c
+++ b/modules/cas_disk/disk.c
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 #include <linux/module.h>

--- a/modules/cas_disk/disk.h
+++ b/modules/cas_disk/disk.h
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 #ifndef __

--- a/modules/cas_disk/exp_obj.c
+++ b/modules/cas_disk/exp_obj.c
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 #include <linux/module.h>

--- a/modules/cas_disk/exp_obj.h
+++ b/modules/cas_disk/exp_obj.h
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 #ifndef __CASDISK_EXP_OBJ_H__

--- a/modules/cas_disk/main.c
+++ b/modules/cas_disk/main.c
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/modules/cas_disk/sysfs.c
+++ b/modules/cas_disk/sysfs.c
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 #include "cas_disk_defs.h"

--- a/modules/cas_disk/sysfs.h
+++ b/modules/cas_disk/sysfs.h
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 #ifndef __CASDISK_SYSFS_H__

--- a/modules/config.mk
+++ b/modules/config.mk
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/modules/extra.mk
+++ b/modules/extra.mk
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 ifneq ($(M),)

--- a/modules/include/cas_ioctl_codes.h
+++ b/modules/include/cas_ioctl_codes.h
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 

--- a/test/functional/api/cas/cache.py
+++ b/test/functional/api/cas/cache.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/api/cas/cache_config.py
+++ b/test/functional/api/cas/cache_config.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/api/cas/cas_module.py
+++ b/test/functional/api/cas/cas_module.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/api/cas/casadm.py
+++ b/test/functional/api/cas/casadm.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/api/cas/casadm_params.py
+++ b/test/functional/api/cas/casadm_params.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/api/cas/casadm_parser.py
+++ b/test/functional/api/cas/casadm_parser.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/api/cas/casctl.py
+++ b/test/functional/api/cas/casctl.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/api/cas/cli.py
+++ b/test/functional/api/cas/cli.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/api/cas/cli_help_messages.py
+++ b/test/functional/api/cas/cli_help_messages.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/api/cas/cli_messages.py
+++ b/test/functional/api/cas/cli_messages.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 import re

--- a/test/functional/api/cas/core.py
+++ b/test/functional/api/cas/core.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 import csv

--- a/test/functional/api/cas/git.py
+++ b/test/functional/api/cas/git.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/api/cas/init_config.py
+++ b/test/functional/api/cas/init_config.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/api/cas/installer.py
+++ b/test/functional/api/cas/installer.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/api/cas/ioclass_config.py
+++ b/test/functional/api/cas/ioclass_config.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/api/cas/statistics.py
+++ b/test/functional/api/cas/statistics.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/api/cas/version.py
+++ b/test/functional/api/cas/version.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/cache_ops/test_cleaning_policy_operation.py
+++ b/test/functional/tests/cache_ops/test_cleaning_policy_operation.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/cache_ops/test_concurrent_flushes.py
+++ b/test/functional/tests/cache_ops/test_concurrent_flushes.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/cache_ops/test_core_remove.py
+++ b/test/functional/tests/cache_ops/test_core_remove.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 import random

--- a/test/functional/tests/cache_ops/test_dynamic_cache_mode_switching.py
+++ b/test/functional/tests/cache_ops/test_dynamic_cache_mode_switching.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/cache_ops/test_multistream_seq_cutoff.py
+++ b/test/functional/tests/cache_ops/test_multistream_seq_cutoff.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 import os

--- a/test/functional/tests/cache_ops/test_seq_cutoff.py
+++ b/test/functional/tests/cache_ops/test_seq_cutoff.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/cli/test_cas_memory_usage.py
+++ b/test/functional/tests/cli/test_cas_memory_usage.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/cli/test_cli_help_and_version.py
+++ b/test/functional/tests/cli/test_cli_help_and_version.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/cli/test_cli_script.py
+++ b/test/functional/tests/cli/test_cli_script.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/cli/test_cli_start_stop.py
+++ b/test/functional/tests/cli/test_cli_start_stop.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/cli/test_seq_cutoff_settings.py
+++ b/test/functional/tests/cli/test_seq_cutoff_settings.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/cli/test_set_get_params.py
+++ b/test/functional/tests/cli/test_set_get_params.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/conftest.py
+++ b/test/functional/tests/conftest.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/data_integrity/test_data_integrity_12h.py
+++ b/test/functional/tests/data_integrity/test_data_integrity_12h.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/data_integrity/test_data_integrity_5d.py
+++ b/test/functional/tests/data_integrity/test_data_integrity_5d.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/example/example_test.py
+++ b/test/functional/tests/example/example_test.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/example/example_test_power_cycle.py
+++ b/test/functional/tests/example/example_test_power_cycle.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/fault_injection/test_another_device_with_same_id.py
+++ b/test/functional/tests/fault_injection/test_another_device_with_same_id.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/fault_injection/test_cache_insert_error.py
+++ b/test/functional/tests/fault_injection/test_cache_insert_error.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/fault_injection/test_fault_injection_interrupts.py
+++ b/test/functional/tests/fault_injection/test_fault_injection_interrupts.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/fault_injection/test_fault_injection_many_to_one.py
+++ b/test/functional/tests/fault_injection/test_fault_injection_many_to_one.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/fault_injection/test_fault_injection_opencas_load.py
+++ b/test/functional/tests/fault_injection/test_fault_injection_opencas_load.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/fault_injection/test_fault_injection_with_mounted_core.py
+++ b/test/functional/tests/fault_injection/test_fault_injection_with_mounted_core.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/fault_injection/test_fault_power_hit_init.py
+++ b/test/functional/tests/fault_injection/test_fault_power_hit_init.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/fault_injection/test_multilevel_cache.py
+++ b/test/functional/tests/fault_injection/test_multilevel_cache.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/fault_injection/test_primary_device_error.py
+++ b/test/functional/tests/fault_injection/test_primary_device_error.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/fault_injection/test_remove_device_during_io.py
+++ b/test/functional/tests/fault_injection/test_remove_device_during_io.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/fault_injection/test_soft_hot_plug_device.py
+++ b/test/functional/tests/fault_injection/test_soft_hot_plug_device.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/incremental_load/test_core_pool.py
+++ b/test/functional/tests/incremental_load/test_core_pool.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/incremental_load/test_inactive_cores.py
+++ b/test/functional/tests/incremental_load/test_inactive_cores.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/incremental_load/test_incremental_load.py
+++ b/test/functional/tests/incremental_load/test_incremental_load.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/incremental_load/test_udev.py
+++ b/test/functional/tests/incremental_load/test_udev.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/initialize/test_clean_reboot.py
+++ b/test/functional/tests/initialize/test_clean_reboot.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/initialize/test_initialize_load.py
+++ b/test/functional/tests/initialize/test_initialize_load.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/initialize/test_initialize_runlevel.py
+++ b/test/functional/tests/initialize/test_initialize_runlevel.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/initialize/test_initialize_status.py
+++ b/test/functional/tests/initialize/test_initialize_status.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 import time

--- a/test/functional/tests/initialize/test_negative_load.py
+++ b/test/functional/tests/initialize/test_negative_load.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/initialize/test_startup_init_config.py
+++ b/test/functional/tests/initialize/test_startup_init_config.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/io/test_io_engines.py
+++ b/test/functional/tests/io/test_io_engines.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/io/test_write_fetch.py
+++ b/test/functional/tests/io/test_write_fetch.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/io/trim/test_trim.py
+++ b/test/functional/tests/io/trim/test_trim.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 import os

--- a/test/functional/tests/io/trim/test_trim_eviction.py
+++ b/test/functional/tests/io/trim/test_trim_eviction.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/io/trim/test_trim_stress.py
+++ b/test/functional/tests/io/trim/test_trim_stress.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/io_class/io_class_common.py
+++ b/test/functional/tests/io_class/io_class_common.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/io_class/test_io_class_cli.py
+++ b/test/functional/tests/io_class/test_io_class_cli.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/io_class/test_io_class_core_id.py
+++ b/test/functional/tests/io_class/test_io_class_core_id.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/io_class/test_io_class_directory.py
+++ b/test/functional/tests/io_class/test_io_class_directory.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/io_class/test_io_class_eviction_priority.py
+++ b/test/functional/tests/io_class/test_io_class_eviction_priority.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/io_class/test_io_class_file.py
+++ b/test/functional/tests/io_class/test_io_class_file.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/io_class/test_io_class_occupancy.py
+++ b/test/functional/tests/io_class/test_io_class_occupancy.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/io_class/test_io_class_occupancy_load.py
+++ b/test/functional/tests/io_class/test_io_class_occupancy_load.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/io_class/test_io_class_occupancy_repart.py
+++ b/test/functional/tests/io_class/test_io_class_occupancy_repart.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/io_class/test_io_class_occupancy_resize.py
+++ b/test/functional/tests/io_class/test_io_class_occupancy_resize.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/io_class/test_io_class_process.py
+++ b/test/functional/tests/io_class/test_io_class_process.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/io_class/test_io_class_purge.py
+++ b/test/functional/tests/io_class/test_io_class_purge.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/io_class/test_io_classification.py
+++ b/test/functional/tests/io_class/test_io_classification.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/lazy_writes/cleaning_policy/test_acp.py
+++ b/test/functional/tests/lazy_writes/cleaning_policy/test_acp.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/lazy_writes/cleaning_policy/test_alru.py
+++ b/test/functional/tests/lazy_writes/cleaning_policy/test_alru.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/lazy_writes/recovery/test_recovery_all_options.py
+++ b/test/functional/tests/lazy_writes/recovery/test_recovery_all_options.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/lazy_writes/recovery/test_recovery_flush_reset.py
+++ b/test/functional/tests/lazy_writes/recovery/test_recovery_flush_reset.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/lazy_writes/recovery/test_recovery_unplug.py
+++ b/test/functional/tests/lazy_writes/recovery/test_recovery_unplug.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/lazy_writes/test_flush_huge_dirty_data.py
+++ b/test/functional/tests/lazy_writes/test_flush_huge_dirty_data.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/lazy_writes/test_lazy_writes_clean.py
+++ b/test/functional/tests/lazy_writes/test_lazy_writes_clean.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/lazy_writes/test_lazy_writes_signals.py
+++ b/test/functional/tests/lazy_writes/test_lazy_writes_signals.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/lazy_writes/test_wb_throttling.py
+++ b/test/functional/tests/lazy_writes/test_wb_throttling.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/misc/test_device_capabilities.py
+++ b/test/functional/tests/misc/test_device_capabilities.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/performance/conftest.py
+++ b/test/functional/tests/performance/conftest.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/performance/test_100p_hits.py
+++ b/test/functional/tests/performance/test_100p_hits.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/security/test_compilation_flags.py
+++ b/test/functional/tests/security/test_compilation_flags.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/security/test_security_user.py
+++ b/test/functional/tests/security/test_security_user.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/stats/test_block_stats.py
+++ b/test/functional/tests/stats/test_block_stats.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/stats/test_consistency_between_outputs.py
+++ b/test/functional/tests/stats/test_consistency_between_outputs.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/stats/test_display_statistics.py
+++ b/test/functional/tests/stats/test_display_statistics.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/stats/test_ioclass_stats.py
+++ b/test/functional/tests/stats/test_ioclass_stats.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 import random

--- a/test/functional/tests/stats/test_stat_max.py
+++ b/test/functional/tests/stats/test_stat_max.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/stats/test_statistics_integrity.py
+++ b/test/functional/tests/stats/test_statistics_integrity.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/stress/test_kedr.py
+++ b/test/functional/tests/stress/test_kedr.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/stress/test_stress_attach_detach.py
+++ b/test/functional/tests/stress/test_stress_attach_detach.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/stress/test_stress_io_small_device.py
+++ b/test/functional/tests/stress/test_stress_io_small_device.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/stress/test_stress_shutdown.py
+++ b/test/functional/tests/stress/test_stress_shutdown.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/stress/test_stress_without_io.py
+++ b/test/functional/tests/stress/test_stress_without_io.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/trim/test_trim.py
+++ b/test/functional/tests/trim/test_trim.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/volumes/test_discard_on_huge_core.py
+++ b/test/functional/tests/volumes/test_discard_on_huge_core.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/volumes/test_raid_as_cache.py
+++ b/test/functional/tests/volumes/test_raid_as_cache.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/tests/volumes/test_volume_partitions.py
+++ b/test/functional/tests/volumes/test_volume_partitions.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/functional/utils/performance.py
+++ b/test/functional/utils/performance.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/smoke_test/basic/01
+++ b/test/smoke_test/basic/01
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/smoke_test/basic/02
+++ b/test/smoke_test/basic/02
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/smoke_test/basic/03
+++ b/test/smoke_test/basic/03
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/smoke_test/basic/04
+++ b/test/smoke_test/basic/04
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/smoke_test/basic/05
+++ b/test/smoke_test/basic/05
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/smoke_test/basic/06
+++ b/test/smoke_test/basic/06
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/smoke_test/basic/07
+++ b/test/smoke_test/basic/07
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/smoke_test/basic/08
+++ b/test/smoke_test/basic/08
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/smoke_test/basic/09
+++ b/test/smoke_test/basic/09
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/smoke_test/basic/10
+++ b/test/smoke_test/basic/10
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/smoke_test/basic/11
+++ b/test/smoke_test/basic/11
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/smoke_test/basic/12
+++ b/test/smoke_test/basic/12
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/smoke_test/basic/13
+++ b/test/smoke_test/basic/13
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/smoke_test/cache_suspend/01
+++ b/test/smoke_test/cache_suspend/01
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/smoke_test/cache_suspend/02
+++ b/test/smoke_test/cache_suspend/02
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/smoke_test/cache_suspend/03
+++ b/test/smoke_test/cache_suspend/03
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/smoke_test/cas_config
+++ b/test/smoke_test/cas_config
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 # Open CAS Linux Tests configuration

--- a/test/smoke_test/cas_functions
+++ b/test/smoke_test/cas_functions
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/smoke_test/cas_lib
+++ b/test/smoke_test/cas_lib
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/smoke_test/cas_local_config.example
+++ b/test/smoke_test/cas_local_config.example
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/smoke_test/cas_options
+++ b/test/smoke_test/cas_options
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 # Whenever adding new options (required or optional), add them to the variable below.

--- a/test/smoke_test/eviction_policy/01
+++ b/test/smoke_test/eviction_policy/01
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/smoke_test/eviction_policy/02
+++ b/test/smoke_test/eviction_policy/02
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/smoke_test/eviction_policy/03
+++ b/test/smoke_test/eviction_policy/03
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/smoke_test/fio/01
+++ b/test/smoke_test/fio/01
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/smoke_test/incremental_load/01
+++ b/test/smoke_test/incremental_load/01
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/smoke_test/incremental_load/02
+++ b/test/smoke_test/incremental_load/02
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/smoke_test/init_script/01
+++ b/test/smoke_test/init_script/01
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/smoke_test/init_script/02
+++ b/test/smoke_test/init_script/02
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/smoke_test/init_script/03
+++ b/test/smoke_test/init_script/03
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/smoke_test/io_class/01_wlth
+++ b/test/smoke_test/io_class/01_wlth
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/smoke_test/io_class/02_wlth
+++ b/test/smoke_test/io_class/02_wlth
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/smoke_test/io_class/cas_lib_io_class
+++ b/test/smoke_test/io_class/cas_lib_io_class
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/smoke_test/metadata_corrupt/01
+++ b/test/smoke_test/metadata_corrupt/01
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/smoke_test/metadata_corrupt/02
+++ b/test/smoke_test/metadata_corrupt/02
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/smoke_test/promotion/01
+++ b/test/smoke_test/promotion/01
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/smoke_test/recovery/01
+++ b/test/smoke_test/recovery/01
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/smoke_test/recovery/02
+++ b/test/smoke_test/recovery/02
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/smoke_test/run_tests
+++ b/test/smoke_test/run_tests
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/smoke_test/write_back/01
+++ b/test/smoke_test/write_back/01
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/smoke_test/write_back/02
+++ b/test/smoke_test/write_back/02
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/utils_tests/opencas-py-tests/conftest.py
+++ b/test/utils_tests/opencas-py-tests/conftest.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/utils_tests/opencas-py-tests/helpers.py
+++ b/test/utils_tests/opencas-py-tests/helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/utils_tests/opencas-py-tests/test_cas_config_01.py
+++ b/test/utils_tests/opencas-py-tests/test_cas_config_01.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/utils_tests/opencas-py-tests/test_cas_config_cache_01.py
+++ b/test/utils_tests/opencas-py-tests/test_cas_config_cache_01.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/utils_tests/opencas-py-tests/test_cas_config_core_01.py
+++ b/test/utils_tests/opencas-py-tests/test_cas_config_core_01.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/utils_tests/opencas-py-tests/test_casadm_01.py
+++ b/test/utils_tests/opencas-py-tests/test_casadm_01.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/test/utils_tests/opencas-py-tests/test_helper_functions_01.py
+++ b/test/utils_tests/opencas-py-tests/test_helper_functions_01.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/tools/cas_version_gen
+++ b/tools/cas_version_gen
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/tools/pckgen
+++ b/tools/pckgen
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/tools/pckgen.d/rpm/CAS_NAME.spec
+++ b/tools/pckgen.d/rpm/CAS_NAME.spec
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/utils/casctl
+++ b/utils/casctl
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/utils/casctl.8
+++ b/utils/casctl.8
@@ -8,7 +8,7 @@ casctl \- whole-configuration-manager for Open CAS.
 \fBcasctl\fR <command> [options...]
 
 .SH COPYRIGHT
-Copyright(c) 2012-2021 by the Intel Corporation.
+Copyright(c) 2012 Intel Corporation.
 
 .SH COMMANDS
 .TP

--- a/utils/open-cas-loader
+++ b/utils/open-cas-loader
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/utils/open-cas-shutdown
+++ b/utils/open-cas-shutdown
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 #

--- a/utils/open-cas.service
+++ b/utils/open-cas.service
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/utils/open-cas.shutdown
+++ b/utils/open-cas.shutdown
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/utils/opencas.conf.5
+++ b/utils/opencas.conf.5
@@ -7,7 +7,7 @@ opencas.conf \- cas configuration file.
 .B /etc/opencas/opencas.conf
 
 .SH COPYRIGHT
-Copyright(c) 2012-2021 by the Intel Corporation.
+Copyright(c) 2012 Intel Corporation.
 
 .SH DESCRIPTION
 Contains configurations for cache and core devices to run cache on system startup. Constist of following sections:

--- a/utils/opencas.py
+++ b/utils/opencas.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 

--- a/utils/upgrade_utils.py
+++ b/utils/upgrade_utils.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 


### PR DESCRIPTION
Leave only file creation date. Edition dates can be easily obtained from
the git repository.

Signed-off-by: Robert Baldyga <robert.baldyga@intel.com>