### PR TITLE
Test updates addressing test fail false positives

### DIFF
--- a/test/functional/tests/lazy_writes/recovery/test_recovery_all_options.py
+++ b/test/functional/tests/lazy_writes/recovery/test_recovery_all_options.py
@@ -4,7 +4,9 @@
 #
 
 import os
+
 import pytest
+
 from api.cas import casadm
 from api.cas.cache_config import CacheMode, CacheModeTrait, CacheLineSize, CleaningPolicy, \
     FlushParametersAcp
@@ -84,6 +86,7 @@ def test_recovery_all_options(cache_mode, cache_line_size, cleaning_policy, file
     with TestRun.step("Reset platform."):
         os_utils.sync()
         core.unmount()
+        os_utils.drop_caches(DropCachesMode.ALL)
         TestRun.LOGGER.info(f"Number of dirty blocks in cache: {cache.get_dirty_blocks()}")
         power_cycle_dut()
 
@@ -106,6 +109,9 @@ def test_recovery_all_options(cache_mode, cache_line_size, cleaning_policy, file
             TestRun.LOGGER.info("Source and target file checksums are identical.")
         else:
             TestRun.fail("Source and target file checksums are different.")
+
+        core_disk.remove_partitions()
+        cache_disk.remove_partitions()
 
 
 def file_operation(target_path, data_pattern, io_pattern):

--- a/test/functional/tests/lazy_writes/recovery/test_recovery_flush_reset.py
+++ b/test/functional/tests/lazy_writes/recovery/test_recovery_flush_reset.py
@@ -4,7 +4,9 @@
 #
 
 import os
+
 import pytest
+
 from api.cas import casadm, cli
 from api.cas.cache_config import CacheMode, CacheModeTrait, CleaningPolicy, SeqCutOffPolicy
 from core.test_run import TestRun
@@ -12,7 +14,7 @@ from storage_devices.disk import DiskTypeSet, DiskType, DiskTypeLowerThan
 from test_tools.disk_utils import Filesystem
 from test_tools.fs_utils import readlink
 from test_utils import os_utils
-from test_utils.os_utils import Udev
+from test_utils.os_utils import Udev, DropCachesMode
 from test_utils.output import CmdException
 from test_utils.size import Size, Unit
 from tests.lazy_writes.recovery.recovery_tests_methods import create_test_files, copy_file, \
@@ -65,6 +67,7 @@ def test_recovery_flush_reset_raw(cache_mode):
             raise CmdException("Error during hdparm", output)
 
     with TestRun.step("Trigger flush."):
+        os_utils.drop_caches(DropCachesMode.ALL)
         TestRun.executor.run_in_background(cli.flush_cache_cmd(f"{cache.cache_id}"))
 
     with TestRun.step("Hard reset DUT during data flushing."):
@@ -153,6 +156,7 @@ def test_recovery_flush_reset_fs(cache_mode, fs):
         core.unmount()
 
     with TestRun.step("Trigger flush."):
+        os_utils.drop_caches(DropCachesMode.ALL)
         TestRun.executor.run_in_background(cli.flush_cache_cmd(f"{cache.cache_id}"))
 
     with TestRun.step("Hard reset DUT during data flushing."):


### PR DESCRIPTION
Shorten blkparse test drastically by using HDD cores
Invert device sizes to eliminate eviction
Fix for request classification
Dropping caches as needed
Device cleanup - for some reason they often interfered with the next test

Signed-off-by: Daniel Madej <daniel.madej@intel.com>