### PR TITLE
When core exported object name exists activation fails and cache is stopped

### DIFF
--- a/modules/cas_cache/layer_cache_management.c
+++ b/modules/cas_cache/layer_cache_management.c
@@ -2297,7 +2297,7 @@ int cache_mngt_activate(struct ocf_mngt_cache_standby_activate_config *cfg,
 	ocf_cache_t cache;
 	struct cache_priv *cache_priv;
 	char cache_name[OCF_CACHE_NAME_SIZE];
-	int result = 0;
+	int result = 0, rollback_result = 0;
 
 	if (!try_module_get(THIS_MODULE))
 		return -KCAS_ERR_SYSTEM;
@@ -2352,13 +2352,14 @@ int cache_mngt_activate(struct ocf_mngt_cache_standby_activate_config *cfg,
 	result = _cache_mngt_async_caller_set_result(&context->async, result);
 	if (result == -KCAS_ERR_WAITING_INTERRUPTED)
 		goto out_cache_put;
-
-	cas_lazy_thread_stop(context->rollback_thread);
-
 	if (result)
-		goto err_free_context;
+		goto err;
 
 	result = _cache_start_finalize(cache, -1, true);
+	if (result)
+		goto err;
+
+	cas_lazy_thread_stop(context->rollback_thread);
 
 err_free_context:
 	kfree(context);
@@ -2370,6 +2371,21 @@ out_cache_put:
 	ocf_mngt_cache_put(cache);
 out_module_put:
 	module_put(THIS_MODULE);
+	return result;
+
+err:
+	reinit_completion(&context->async.cmpl);
+	context->async.result = 0;
+	ocf_mngt_cache_stop(cache, _cache_mngt_cache_stop_rollback_complete,
+			context);
+	rollback_result = wait_for_completion_interruptible(&context->async.cmpl);
+	
+	rollback_result = _cache_mngt_async_caller_set_result(&context->async,
+							rollback_result);
+	
+	if (rollback_result != -KCAS_ERR_WAITING_INTERRUPTED)
+		kfree(context);
+	
 	return result;
 }
 


### PR DESCRIPTION
fixes #1022 

Signed-off-by: Piotr Debski <piotr.debski@intel.com>