### PR TITLE
casadm standby cache commands for tests

### DIFF
--- a/test/functional/api/cas/casadm.py
+++ b/test/functional/api/cas/casadm.py
@@ -42,6 +42,55 @@ def start_cache(cache_dev: Device, cache_mode: CacheMode = None,
     return Cache(cache_dev)
 
 
+def standby_init(cache_dev: Device, cache_id: int, cache_line_size: CacheLineSize,
+                 force: bool = False, shortcut: bool = False,
+                 kernel_params: KernelParameters = KernelParameters()):
+    if kernel_params != KernelParameters.read_current_settings():
+        reload_kernel_module("cas_cache", kernel_params.get_parameter_dictionary())
+    output = TestRun.executor.run(
+        standby_init_cmd(
+            cache_dev=cache_dev.path,
+            cache_id=str(cache_id),
+            cache_line_size=str(cache_line_size),
+            force=force,
+            shortcut=shortcut,
+        )
+    )
+    if output.exit_code != 0:
+        raise CmdException("Failed to init standby cache.", output)
+    return Cache(cache_dev)
+
+
+def standby_load(cache_dev: Device, shortcut: bool = False):
+    output = TestRun.executor.run(
+        standby_load_cmd(cache_dev=cache_dev.path, shortcut=shortcut)
+    )
+    if output.exit_code != 0:
+        raise CmdException("Failed to load standby cache.", output)
+    return Cache(cache_dev)
+
+
+def standby_detach_cache(cache_id: int, shortcut: bool = False):
+    output = TestRun.executor.run(
+        standby_detach_cmd(cache_id=str(cache_id), shortcut=shortcut)
+    )
+    if output.exit_code != 0:
+        raise CmdException("Failed to detach standby cache.", output)
+    return output
+
+
+def standby_activate_cache(cache_dev: Device, cache_id: int, shortcut: bool = False):
+    output = TestRun.executor.run(
+        standby_activate_cmd(
+            cache_dev=cache_dev.path, cache_id=str(cache_id), shortcut=shortcut
+        )
+    )
+    if output.exit_code != 0:
+        raise CmdException("Failed to activate standby cache.", output)
+    return output
+
+
+
 def stop_cache(cache_id: int, no_data_flush: bool = False, shortcut: bool = False):
     output = TestRun.executor.run(
         stop_cmd(cache_id=str(cache_id), no_data_flush=no_data_flush, shortcut=shortcut))

--- a/test/functional/api/cas/cli.py
+++ b/test/functional/api/cas/cli.py
@@ -108,6 +108,36 @@ def start_cmd(cache_dev: str, cache_mode: str = None, cache_line_size: str = Non
     return casadm_bin + command
 
 
+def standby_init_cmd(cache_dev: str, cache_id: str, cache_line_size: str,
+                     force: bool = False, shortcut: bool = False):
+    command = " --standby --init"
+    command += (" -d " if shortcut else " --cache-device ") + cache_dev
+    command += (" -i " if shortcut else " --cache-id ") + cache_id
+    command += (" -x " if shortcut else " --cache-line-size ") + cache_line_size
+    if force:
+        command += " -f" if shortcut else " --force"
+    return casadm_bin + command
+
+
+def standby_load_cmd(cache_dev: str, shortcut: bool = False):
+    command = " --standby --load"
+    command += (" -d " if shortcut else " --cache-device ") + cache_dev
+    return casadm_bin + command
+
+
+def standby_detach_cmd(cache_id: str, shortcut: bool = False):
+    command = " --standby --detach"
+    command += (" -i " if shortcut else " --cache-id ") + cache_id
+    return casadm_bin + command
+
+
+def standby_activate_cmd(cache_dev: str, cache_id: str, shortcut: bool = False):
+    command = " --standby --activate"
+    command += (" -d " if shortcut else " --cache-device ") + cache_dev
+    command += (" -i " if shortcut else " --cache-id ") + cache_id
+    return casadm_bin + command
+
+
 def print_statistics_cmd(cache_id: str, core_id: str = None, per_io_class: bool = False,
                          io_class_id: str = None, filter: str = None,
                          output_format: str = None, by_id_path: bool = True,


### PR DESCRIPTION
New casadm commands for standby mode and change of naming convention following new design.