### PR TITLE
casadm: set log level when printing cmd's usage

### DIFF
--- a/casadm/argp.c
+++ b/casadm/argp.c
@@ -64,8 +64,9 @@ char *command_name_in_brackets(char *buf, size_t buf_size, char short_name, char
 	return buf;
 }
 
-void print_options_usage(cli_option* options, const char *separator,
-		int (*view)(cli_option* options, int flag), int flag)
+void print_options_usage(int log_level, cli_option* options,
+		const char *separator, int (*view)(cli_option* options, int flag),
+		int flag)
 {
 	int print_separator = 0;
 	int i;
@@ -81,16 +82,16 @@ void print_options_usage(cli_option* options, const char *separator,
 
 		if (print_separator) {
 			/* Separator */
-			cas_printf(LOG_INFO, "%s", separator);
+			cas_printf(log_level, "%s", separator);
 		}
 		print_separator = 1;
 
 		/* Long option name */
-		cas_printf(LOG_INFO, "--%s", options[i].long_name);
+		cas_printf(log_level, "--%s", options[i].long_name);
 
 		/* Parameter */
 		if (options[i].arg != NULL) {
-			cas_printf(LOG_INFO, " <%s>",
+			cas_printf(log_level, " <%s>",
 			options[i].arg);
 		}
 	}

--- a/casadm/argp.h
+++ b/casadm/argp.h
@@ -119,8 +119,9 @@ char *command_name_in_brackets(char *buf, size_t buf_size, char short_name, char
 
 void print_help(const app *app_values, const cli_command *commands);
 
-void print_options_usage(cli_option* options, const char *separator,
-		int (*view)(cli_option* options, int flag), int flag);
+void print_options_usage(int log_level, cli_option* options,
+		const char *separator, int (*view)(cli_option* options, int flag),
+		int flag);
 
 void print_list_options(cli_option* options, int flag,
 		int (*view)(cli_option* options, int flag));

--- a/casadm/cas_main.c
+++ b/casadm/cas_main.c
@@ -170,7 +170,7 @@ static inline void cmd_subcmd_print_invalid_subcmd(cli_option* options)
 {
 	cas_printf(LOG_ERR, "Invalid or missing first sub-command parameter. ");
 	cas_printf(LOG_ERR, "Expected one of the: {");
-	print_options_usage(options, "|", cmd_subcmd_print_subcmd, 0);
+	print_options_usage(LOG_ERR, options, "|", cmd_subcmd_print_subcmd, 0);
 	cas_printf(LOG_ERR, "}\n");
 }
 
@@ -183,7 +183,7 @@ void cmd_subcmd_help(app *app_values, cli_command *cmd, int flag_required)
 
 	/* Print usage */
 	cas_printf(LOG_INFO, "Usage: %s --%s {", app_values->name, cmd->name);
-	print_options_usage(cmd->options, "|", cmd_subcmd_print_subcmd, 0);
+	print_options_usage(LOG_INFO, cmd->options, "|", cmd_subcmd_print_subcmd, 0);
 	cas_printf(LOG_INFO, "}\n\n");
 
 	print_command_header(app_values, cmd);
@@ -217,7 +217,7 @@ void cmd_subcmd_help(app *app_values, cli_command *cmd, int flag_required)
 			}
 		}
 
-		print_options_usage(cmd->options, " ", cmd_subcmd_print_param,
+		print_options_usage(LOG_INFO, cmd->options, " ", cmd_subcmd_print_param,
 				(1 << flag) | (1 << flag_required));
 
 		if (all_ops != printed_ops) {


### PR DESCRIPTION
Allow printing command's usage with the same log level as it's context

Closes #1076 

Signed-off-by: Michal Mielewczyk <michal.mielewczyk@intel.com>