### PR TITLE
configure/bio_max_vecs: adapt to kernel 5.12

### DIFF
--- a/configure.d/1_bio_max_vecs.conf
+++ b/configure.d/1_bio_max_vecs.conf
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# Copyright(c) 2022 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+. $(dirname $3)/conf_framework
+
+check() {
+    cur_name=$(basename $2)
+    config_file_path=$1
+    if compile_module $cur_name "int n; n = BIO_MAX_VECS" "linux/bio.h"
+    then
+        echo $cur_name 1 >> $config_file_path
+    else
+        echo $cur_name 2 >> $config_file_path
+    fi
+}
+
+apply() {
+    case "$1" in
+    "1")
+	;;
+    "2")
+        add_define "BIO_MAX_VECS ((uint32_t)(-1))" ;;
+    *)
+        exit 1
+    esac
+}
+
+conf_run $@

--- a/modules/cas_cache/volume/vol_blk_utils.h
+++ b/modules/cas_cache/volume/vol_blk_utils.h
@@ -90,7 +90,7 @@ static inline uint32_t cas_io_iter_size_done(struct bio_vec_iter *iter)
 static inline uint32_t cas_io_iter_size_left(struct bio_vec_iter *iter)
 {
 	if (iter->idx < iter->vec_size)
-		return iter->vec_size - iter->idx;
+		return min(iter->vec_size - iter->idx, BIO_MAX_VECS);
 	return 0;
 	/* TODO UNITTEST */
 }


### PR DESCRIPTION
The bio_alloc_bioset() function now BUG() if trying to allocate a bio
with more than BIO_MAX_VECS vectors.

A no-limit value (-1) is defined in order not to change old kernels'
behaviour.

Signed-off-by: Gal Hammer <gal.hammer@huawei.com>
Signed-off-by: Shai Fultheim <shai.fultheim@huawei.com>