### PR TITLE
Fix mising casadm error message

### DIFF
--- a/casadm/cas_lib.c
+++ b/casadm/cas_lib.c
@@ -636,6 +636,9 @@ int set_device_path(char *dest_path, size_t dest_len, const char *src_path, size
 			cas_printf(LOG_ERR, "Internal error copying device path\n");
 	}
 
+	cas_printf(LOG_ERR, "Please use correct by-id path to the device %s.\n",
+		   src_path);
+
 	return FAILURE;
 }
 
@@ -993,8 +996,6 @@ int start_cache(uint16_t cache_id, unsigned int cache_init,
 	cmd.init_cache = cache_init;
 	if (set_device_path(cmd.cache_path_name, sizeof(cmd.cache_path_name),
 			    cache_device, MAX_STR_LEN) != SUCCESS) {
-		cas_printf(LOG_ERR, "Please use correct by-id path to the device "
-			   "%s.\n", cache_device);
 		close(fd);
 		return FAILURE;
 	}
@@ -1696,11 +1697,8 @@ int add_core(unsigned int cache_id, unsigned int core_id, const char *core_devic
 
 	memset(&cmd, 0, sizeof(cmd));
 	if (set_device_path(cmd.core_path_name, sizeof(cmd.core_path_name),
-			    core_device, MAX_STR_LEN) != SUCCESS) {
-		cas_printf(LOG_ERR, "Please use correct by-id path to the device "
-			   "%s.\n", core_device);
+			    core_device, MAX_STR_LEN) != SUCCESS)
 		return FAILURE;
-	}
 
 	user_core_path = core_device;
 	user_core_path_size = strnlen_s(core_device, MAX_STR_LEN);
@@ -1901,8 +1899,6 @@ int core_pool_remove(const char *core_device)
 
 	if (set_device_path(cmd.core_path_name, sizeof(cmd.core_path_name),
 			    core_device, MAX_STR_LEN) != SUCCESS) {
-		cas_printf(LOG_ERR, "Please use correct by-id path to the device "
-			   "%s.\n", core_device);
 		close(fd);
 		return FAILURE;
 	}
@@ -2873,11 +2869,8 @@ int check_cache_device(const char *device_path)
 	int result;
 
 	if (set_device_path(cmd_info.path_name, sizeof(cmd_info.path_name),
-			    device_path, MAX_STR_LEN) != SUCCESS) {
-		cas_printf(LOG_ERR, "Please use correct by-id path to the device "
-			   "%s.\n", device_path);
+			    device_path, MAX_STR_LEN) != SUCCESS)
 		return FAILURE;
-	}
 
 	result = _check_cache_device(device_path, &cmd_info);
 


### PR DESCRIPTION
This patch fixes missing casadm message when --standby --activate
is used with a direct path to a non-whitelisted device.

Signed-off-by: Krzysztof Majzerowicz-Jaszcz <krzysztof.majzerowicz-jaszcz@intel.com>