### PR TITLE
Casctl: Python version check fix

### DIFF
--- a/utils/casctl
+++ b/utils/casctl
@@ -3,20 +3,12 @@
 # Copyright(c) 2012-2021 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
-
-import platform
 import sys
 
-min_ver = "3.6"
-ver = platform.python_version()
-if ver < min_ver:
-    print(
-        "Minimum required python version is {}. Detected python version is {}".format(
-            min_ver,
-            ver,
-        ),
-        file=sys.stderr,
-    )
+min_ver = (3, 6)
+if sys.version_info < min_ver:
+    print("Minimum required python version is {}.{}. Detected python version is '{}'"
+          .format(*min_ver, sys.version), file=sys.stderr)
     exit(1)
 
 import argparse


### PR DESCRIPTION
Fixes the python version check code in the casctl.

Signed-off-by: Krzysztof Majzerowicz-Jaszcz <krzysztof.majzerowicz-jaszcz@intel.com>