### PR TITLE
cas_cache: fix "blk_update_request: operation not supported" error

### DIFF
--- a/modules/cas_cache/volume/vol_block_dev_bottom.c
+++ b/modules/cas_cache/volume/vol_block_dev_bottom.c
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012-2022 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 
@@ -354,6 +354,21 @@ static inline bool cas_bd_io_prepare(int *dir, struct ocf_io *io)
 }
 
 /*
+ * Returns only flags that are relevant to request's direction.
+ */
+static inline uint64_t filter_req_flags(int dir, uint64_t flags)
+{
+	/* Remove REQ_RAHEAD flag from write request to cache which are a
+	   result of a missed read-head request. This flag caused the nvme
+	   driver to send write command with an access frequency value that
+	   is reserved */
+	if (dir == WRITE)
+		flags &= ~REQ_RAHEAD;
+
+	return flags;
+}
+
+/*
  *
  */
 static void block_dev_submit_io(struct ocf_io *io)
@@ -403,7 +418,7 @@ static void block_dev_submit_io(struct ocf_io *io)
 		CAS_BIO_BISECTOR(bio) = addr / SECTOR_SIZE;
 		bio->bi_next = NULL;
 		bio->bi_private = io;
-		CAS_BIO_OP_FLAGS(bio) |= io->flags;
+		CAS_BIO_OP_FLAGS(bio) |= filter_req_flags(dir, io->flags);
 		bio->bi_end_io = CAS_REFER_BLOCK_CALLBACK(cas_bd_io_end);
 
 		/* Add pages */


### PR DESCRIPTION
A write request with the REQ_RAHEAD flag enabled cause the nvme driver
to send a write command with access frequency value that is reserved
(at least on specification version 1.4c). NVME devices might fail this
write command with an unsupported error. So we now clear the request's
flag based on its direction.

Signed-off-by: Gal Hammer <gal.hammer@huawei.com>
Signed-off-by: Shai Fultheim <shai.fultheim@huawei.com>