### PR TITLE
Fix for #1224 - kernel crash in the IO path

### DIFF
--- a/configure.d/1_bio_split.conf
+++ b/configure.d/1_bio_split.conf
@@ -26,7 +26,7 @@ apply() {
         add_function "
     static inline struct bio *cas_bio_split(struct bio *bio, int sectors)
     {
-        return bio_split(bio, sectors, GFP_NOIO, NULL);
+        return bio_split(bio, sectors, GFP_NOIO, &fs_bio_set);
     }" ;;
     "2")
         add_function "


### PR DESCRIPTION
This fixes issue #1224 - null pointer dereference in kernel in the IO path with large IO's issued

Signed-off-by: Krzysztof Majzerowicz-Jaszcz <krzysztof.majzerowicz-jaszcz@intel.com>