### PR TITLE
Fix for null pointer dereference bug

### DIFF
--- a/modules/cas_cache/layer_cache_management.c
+++ b/modules/cas_cache/layer_cache_management.c
@@ -2946,7 +2946,7 @@ int cache_mngt_exit_instance(const char *cache_name, size_t name_len, int flush)
 			goto stop_thread;
 		}
 	} else {
-		status = kcas_cache_destroy_exported_object(cache);
+		status = cache_mngt_destroy_cache_exp_obj(cache);
 		if (status != 0) {
 			printk(KERN_WARNING
 					"Failed to remove cache exported object\n");

--- a/modules/cas_cache/volume/vol_block_dev_top.c
+++ b/modules/cas_cache/volume/vol_block_dev_top.c
@@ -571,8 +571,13 @@ end:
 
 static int kcas_volume_destroy_exported_object(ocf_volume_t volume)
 {
-	struct bd_object *bvol = bd_object(volume);
+	struct bd_object *bvol;
 	int result;
+
+	BUG_ON(!volume);
+
+	bvol = bd_object(volume);
+	BUG_ON(!bvol);
 
 	if (!bvol->expobj_valid)
 		return 0;


### PR DESCRIPTION
Null pointer dereference occurs when terminating cache is standby detached state.
This fixes this problem.

Fixes #1235

Signed-off-by: Krzysztof Majzerowicz-Jaszcz <krzysztof.majzerowicz-jaszcz@intel.com>