### PR TITLE
Fix standby detach

### DIFF
--- a/casadm/cas_main.c
+++ b/casadm/cas_main.c
@@ -2116,9 +2116,11 @@ int standby_handle() {
 		return FAILURE;
 	}
 
-	if (validate_cache_path(standby_params.cache_device,
-				standby_params.force) == FAILURE) {
-		return FAILURE;
+	if (standby_params.subcmd != standby_opt_subcmd_detach) {
+		if (validate_cache_path(standby_params.cache_device,
+					standby_params.force) == FAILURE) {
+			return FAILURE;
+		}
 	}
 
 	switch (standby_params.subcmd) {


### PR DESCRIPTION
As the check added in commit a90839f2863 tries to open the caching devcie
exclusively, it is impossible to detach cache from a standby instance.

Fixes #1258 

Signed-off-by: Michal Mielewczyk <michal.mielewczyk@intel.com>