### PR TITLE
API fix for casadm standby init

### DIFF
--- a/test/functional/api/cas/casadm.py
+++ b/test/functional/api/cas/casadm.py
@@ -47,11 +47,15 @@ def standby_init(cache_dev: Device, cache_id: int, cache_line_size: CacheLineSiz
                  kernel_params: KernelParameters = KernelParameters()):
     if kernel_params != KernelParameters.read_current_settings():
         reload_kernel_module("cas_cache", kernel_params.get_parameter_dictionary())
+
+    _cache_line_size = None if cache_line_size is None else str(
+        int(cache_line_size.value.get_value(Unit.KibiByte)))
+
     output = TestRun.executor.run(
         standby_init_cmd(
             cache_dev=cache_dev.path,
             cache_id=str(cache_id),
-            cache_line_size=str(cache_line_size),
+            cache_line_size=_cache_line_size,
             force=force,
             shortcut=shortcut,
         )

--- a/test/functional/tests/cli/test_cli_standby.py
+++ b/test/functional/tests/cli/test_cli_standby.py
@@ -119,12 +119,12 @@ def test_activate_neg_cli_params():
         cache_device.create_partitions([Size(500, Unit.MebiByte)])
         cache_device = cache_device.partitions[0]
         cache_id = 1
-        cache_line_size = 32
 
     with TestRun.step("Init standby cache"):
         cache_dev = Device(cache_device.path)
         cache = standby_init(
-            cache_dev=cache_dev, cache_id=cache_id, cache_line_size=cache_line_size, force=True
+            cache_dev=cache_dev, cache_id=cache_id,
+            cache_line_size=CacheLineSize.LINE_32KiB, force=True
         )
 
     with TestRun.step("Detach standby cache"):
@@ -202,7 +202,8 @@ def test_standby_neg_cli_management():
     with TestRun.step("Prepare the standby instance"):
         cache_id = 1
         cache = casadm.standby_init(
-            cache_dev=cache_device, cache_id=cache_id, cache_line_size=32, force=True
+            cache_dev=cache_device, cache_id=cache_id,
+            cache_line_size=CacheLineSize.LINE_32KiB, force=True
         )
 
         ioclass_config_path = "/tmp/standby_cli_neg_mngt_test_ioclass_config_file.csv"
@@ -425,8 +426,7 @@ def test_activate_neg_cache_line_size():
 
         with TestRun.step("Start standby cache instance."):
             standby_cache = casadm.standby_init(cache_dev=standby_cache_dev, cache_id=cache_id,
-                                                cache_line_size=int(
-                                                    standby_cls.value.value / Unit.KibiByte.value),
+                                                cache_line_size=standby_cls,
                                                 force=True)
 
         with TestRun.step("Verify if the cache exported object appeared in the system"):
@@ -484,7 +484,7 @@ def test_standby_init_with_preexisting_metadata():
     with TestRun.step("Start standby cache instance"):
         cache = casadm.standby_init(
             cache_dev=cache_device,
-            cache_line_size=int(cls.value.value / Unit.KibiByte.value),
+            cache_line_size=cls,
             cache_id=cache_id,
             force=True,
         )
@@ -509,7 +509,7 @@ def test_standby_init_with_preexisting_metadata():
     with TestRun.step("Try initialize cache with force flag"):
         casadm.standby_init(
             cache_dev=cache_device,
-            cache_line_size=int(cls.value.value / Unit.KibiByte.value),
+            cache_line_size=cls,
             cache_id=cache_id,
             force=True,
         )
@@ -559,7 +559,7 @@ def test_standby_init_with_preexisting_filesystem(filesystem):
     with TestRun.step("Try initialize cache with force flag"):
         casadm.standby_init(
             cache_dev=cache_device,
-            cache_line_size=int(cls.value.value / Unit.KibiByte.value),
+            cache_line_size=cls,
             cache_id=cache_id,
             force=True,
         )

--- a/test/functional/tests/failover_standby/test_failover_multihost.py
+++ b/test/functional/tests/failover_standby/test_failover_multihost.py
@@ -100,7 +100,7 @@ def test_functional_activate_twice_round_trip(filesystem):
     ):
         secondary_node.cache = casadm.standby_init(
             cache_dev=secondary_node.raid,
-            cache_line_size=str(cls.value.value // 1024),
+            cache_line_size=cls,
             cache_id=cache_id,
             force=True,
         )
@@ -270,7 +270,7 @@ def test_functional_activate_twice_new_host(filesystem):
     ):
         secondary_node.cache = casadm.standby_init(
             cache_dev=secondary_node.raid,
-            cache_line_size=str(cls.value.value // 1024),
+            cache_line_size=cls,
             cache_id=cache_id,
             force=True,
         )
@@ -545,7 +545,7 @@ def new_failover_instance(new_secondary_node, drbd_resource, *, autoload):
         ):
             new_secondary_node.cache = casadm.standby_init(
                 cache_dev=new_secondary_node.raid,
-                cache_line_size=str(cls.value.value // 1024),
+                cache_line_size=cls,
                 cache_id=cache_id,
                 force=True,
             )

--- a/test/functional/tests/fault_injection/test_fault_injection_standby.py
+++ b/test/functional/tests/fault_injection/test_fault_injection_standby.py
@@ -53,7 +53,7 @@ def test_activate_corrupted():
         with TestRun.step("Prepare standby instance"):
             cache = casadm.standby_init(
                 cache_dev=cache_device,
-                cache_line_size=int(cls.value.value / Unit.KibiByte.value),
+                cache_line_size=cls,
                 cache_id=cache_id,
                 force=True,
             )
@@ -154,7 +154,7 @@ def test_activate_corrupted_after_dump():
         with TestRun.step("Prepare standby instance"):
             cache = casadm.standby_init(
                 cache_dev=cache_device,
-                cache_line_size=int(cls.value.value / Unit.KibiByte.value),
+                cache_line_size=cls,
                 cache_id=cache_id,
                 force=True,
             )

--- a/test/functional/tests/fault_injection/test_fault_injection_standby_core.py
+++ b/test/functional/tests/fault_injection/test_fault_injection_standby_core.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019-2022 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
@@ -62,7 +62,7 @@ def test_activate_neg_cache_id():
     ):
         standby_cache = casadm.standby_init(
             standby_dev,
-            cache_line_size=int(cls.value.value / Unit.KibiByte.value),
+            cache_line_size=cls,
             cache_id=standby_cache_id,
             force=True,
         )


### PR DESCRIPTION
Cache line size parameter is handled inconsistently in standby init and
start cache methods.

This patch fixes this inconsistency so both methods accept a proper
CacheLineSize object.

Some of the existing tests needed fixing as well, as included in this
patch.

Signed-off-by: Krzysztof Majzerowicz-Jaszcz <krzysztof.majzerowicz-jaszcz@intel.com>