### PR TITLE
Fix for tests using get_metadata_size()

### DIFF
--- a/test/functional/api/cas/dmesg.py
+++ b/test/functional/api/cas/dmesg.py
@@ -8,13 +8,13 @@ import re
 from test_utils.size import Size, Unit
 
 
-def get_metadata_size(dmesg):
+def get_metadata_size_on_device(dmesg):
     for s in dmesg.split("\n"):
-        if "Metadata capacity:" in s:
-            size = re.search("[0-9]* MiB", s).group()
-            return Size(int(re.search("[0-9]*", size).group()), Unit.MebiByte)
+        m = re.search(r'Metadata size on device: ([0-9]*) kiB', s)
+        if m:
+            return Size(int(m.groups()[0]), Unit.KibiByte)
 
-    raise ValueError("Can't find the metadata size in the privded dmesg output")
+    raise ValueError("Can't find the metadata size in the provided dmesg output")
 
 
 def _get_metadata_info(dmesg, section_name):

--- a/test/functional/tests/cli/test_cli_standby.py
+++ b/test/functional/tests/cli/test_cli_standby.py
@@ -404,13 +404,12 @@ def test_activate_neg_cache_line_size():
         with TestRun.step("Create dump file with cache metadata"):
             with TestRun.step("Get metadata size"):
                 dmesg_out = TestRun.executor.run_expect_success("dmesg").stdout
-                md_size = dmesg.get_metadata_size(dmesg_out)
+                md_size = dmesg.get_metadata_size_on_device(dmesg_out)
 
             with TestRun.step("Dump the metadata of the cache"):
                 dump_file_path = "/tmp/test_activate_corrupted.dump"
                 md_dump = File(dump_file_path)
                 md_dump.remove(force=True, ignore_errors=True)
-
                 dd_count = int(md_size / Size(1, Unit.MebiByte)) + 1
                 (
                     Dd().input(active_cache_dev.path)

--- a/test/functional/tests/fault_injection/test_fault_injection_standby.py
+++ b/test/functional/tests/fault_injection/test_fault_injection_standby.py
@@ -207,7 +207,7 @@ def prepare_md_dump(cache_device, core_device, cls, cache_id):
 
     with TestRun.step("Get metadata size"):
         dmesg_out = TestRun.executor.run_expect_success("dmesg").stdout
-        md_size = dmesg.get_metadata_size(dmesg_out)
+        md_size = dmesg.get_metadata_size_on_device(dmesg_out)
 
     with TestRun.step("Dump the metadata of the cache"):
         dump_file_path = "/tmp/test_activate_corrupted.dump"


### PR DESCRIPTION
Since OCF has changed how metadata size is reported (OCF PR Open-CAS/ocf#744 ),
get_metadata_size() became get_metadata_size_on_device() and tests
using it are changed accordingly.

Signed-off-by: Krzysztof Majzerowicz-Jaszcz <krzysztof.majzerowicz-jaszcz@intel.com>