### PR TITLE
Add CI marks to standby fault injection tests

### DIFF
--- a/test/functional/tests/fault_injection/test_fault_injection_standby.py
+++ b/test/functional/tests/fault_injection/test_fault_injection_standby.py
@@ -25,6 +25,7 @@ from test_utils.filesystem.file import File
 block_size = Size(1, Unit.Blocks512)
 
 
+@pytest.mark.CI
 @pytest.mark.require_disk("cache", DiskTypeSet([DiskType.nand, DiskType.optane]))
 @pytest.mark.require_disk("core", DiskTypeLowerThan("cache"))
 def test_activate_corrupted():
@@ -81,6 +82,7 @@ def test_activate_corrupted():
         md_dump.remove()
 
 
+@pytest.mark.CI
 @pytest.mark.require_disk("cache", DiskTypeSet([DiskType.nand, DiskType.optane]))
 @pytest.mark.require_disk("core", DiskTypeLowerThan("cache"))
 def test_load_corrupted():
@@ -125,6 +127,7 @@ def test_load_corrupted():
         md_dump.remove()
 
 
+@pytest.mark.CI
 @pytest.mark.require_disk("cache", DiskTypeSet([DiskType.nand, DiskType.optane]))
 @pytest.mark.require_disk("core", DiskTypeLowerThan("cache"))
 def test_activate_corrupted_after_dump():


### PR DESCRIPTION
requires https://github.com/intel-innersource/frameworks.validation.opencas.test-framework/pull/49
Signed-off-by: Piotr Debski <piotr.debski@intel.com>