### PR TITLE
Add missing semicolons in configure scripts

### DIFF
--- a/configure.d/1_append_bio.conf
+++ b/configure.d/1_append_bio.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012-2022 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
@@ -10,7 +10,7 @@
 check() {
 	cur_name=$(basename $2)
 	config_file_path=$1
-    if compile_module $cur_name "struct bio *b;blk_rq_append_bio(NULL, &b)" "linux/blkdev.h"
+    if compile_module $cur_name "struct bio *b;blk_rq_append_bio(NULL, &b);" "linux/blkdev.h"
     then
         echo $cur_name 1 >> $config_file_path
     else

--- a/configure.d/1_bd_first_part.conf
+++ b/configure.d/1_bd_first_part.conf
@@ -9,7 +9,7 @@
 check() {
 	cur_name=$(basename $2)
 	config_file_path=$1
-	if compile_module $cur_name "struct gendisk *disk = NULL; struct xarray xa; xa = disk->part_tbl" "linux/genhd.h"
+	if compile_module $cur_name "struct gendisk *disk = NULL; struct xarray xa; xa = disk->part_tbl;" "linux/genhd.h"
 	then
 		echo $cur_name "1" >> $config_file_path
 	elif compile_module $cur_name "struct block_device bd; bd = *disk_part_iter_next(NULL);" "linux/blk_types.h"

--- a/configure.d/1_bio_max_vecs.conf
+++ b/configure.d/1_bio_max_vecs.conf
@@ -9,7 +9,7 @@
 check() {
     cur_name=$(basename $2)
     config_file_path=$1
-    if compile_module $cur_name "int n; n = BIO_MAX_VECS" "linux/bio.h"
+    if compile_module $cur_name "int n; n = BIO_MAX_VECS;" "linux/bio.h"
     then
         echo $cur_name 1 >> $config_file_path
     else

--- a/configure.d/1_biovec.conf
+++ b/configure.d/1_biovec.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012-2022 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
@@ -9,7 +9,7 @@
 check() {
 	cur_name=$(basename $2)
 	config_file_path=$1
-	if compile_module $cur_name "struct bio b;&bio_iovec(&b)" "linux/bio.h"
+	if compile_module $cur_name "struct bio b;&bio_iovec(&b);" "linux/bio.h"
 	then
 		echo $cur_name "1" >> $config_file_path
 	else

--- a/configure.d/1_blk_status.conf
+++ b/configure.d/1_blk_status.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012-2022 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
@@ -9,7 +9,7 @@
 check() {
 	cur_name=$(basename $2)
 	config_file_path=$1
-	if compile_module $cur_name "blk_status_t t" "linux/blk_types.h"
+	if compile_module $cur_name "blk_status_t t;" "linux/blk_types.h"
 	then
 		echo $cur_name "1" >> $config_file_path
 	else

--- a/configure.d/1_deamonize.conf
+++ b/configure.d/1_deamonize.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012-2022 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
@@ -9,7 +9,7 @@
 check() {
 	cur_name=$(basename $2)
 	config_file_path=$1
-	if compile_module $cur_name "deamonize(\"some_name\", NULL)" "linux/sched.h"
+	if compile_module $cur_name "deamonize(\"some_name\", NULL);" "linux/sched.h"
 	then
 		echo $cur_name "1" >> $config_file_path
 	else

--- a/configure.d/1_discard_zeros.conf
+++ b/configure.d/1_discard_zeros.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012-2022 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
@@ -9,7 +9,7 @@
 check() {
 	cur_name=$(basename $2)
 	config_file_path=$1
-	if compile_module $cur_name "struct queue_limits q;q.discard_zeroes_data" "linux/blkdev.h"
+	if compile_module $cur_name "struct queue_limits q;q.discard_zeroes_data;" "linux/blkdev.h"
 	then
 		echo $cur_name "1" >> $config_file_path
 	else

--- a/configure.d/1_err_no_to_blk_sts.conf
+++ b/configure.d/1_err_no_to_blk_sts.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012-2022 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
@@ -9,7 +9,7 @@
 check() {
 	cur_name=$(basename $2)
 	config_file_path=$1
-	if compile_module $cur_name "errno_to_blk_status(0)" "linux/blkdev.h"
+	if compile_module $cur_name "errno_to_blk_status(0);" "linux/blkdev.h"
 	then
 		echo $cur_name "1" >> $config_file_path
 	else

--- a/configure.d/1_kallsyms_on_each_symbol.conf
+++ b/configure.d/1_kallsyms_on_each_symbol.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012-2022 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
@@ -9,7 +9,7 @@
 check() {
     cur_name=$(basename $2)
     config_file_path=$1
-    if compile_module $cur_name "kallsyms_on_each_symbol(NULL, NULL)" "linux/fs.h"
+    if compile_module $cur_name "kallsyms_on_each_symbol(NULL, NULL);" "linux/fs.h"
     then
         echo $cur_name "1" >> $config_file_path
     else

--- a/configure.d/1_make_request.conf
+++ b/configure.d/1_make_request.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012-2022 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
@@ -9,7 +9,7 @@
 check() {
     cur_name=$(basename $2)
     config_file_path=$1
-    if compile_module $cur_name "blk_queue_make_request" "linux/blkdev.h"
+    if compile_module $cur_name "blk_queue_make_request;" "linux/blkdev.h"
     then
         echo $cur_name "1" >> $config_file_path
     elif compile_module $cur_name "struct request_queue *q; q->make_request_fn;" "linux/blkdev.h"

--- a/configure.d/1_mq_flags.conf
+++ b/configure.d/1_mq_flags.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012-2022 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
@@ -12,12 +12,12 @@ check() {
 
     output=0
 
-    if compile_module $cur_name "BLK_MQ_F_STACKING " "linux/blk-mq.h"
+    if compile_module $cur_name "BLK_MQ_F_STACKING ;" "linux/blk-mq.h"
     then
         output=1
     fi
 
-    if compile_module $cur_name "BLK_MQ_F_BLOCKING " "linux/blk-mq.h"
+    if compile_module $cur_name "BLK_MQ_F_BLOCKING ;" "linux/blk-mq.h"
     then
         output=$((output+2))
     fi

--- a/configure.d/1_munmap.conf
+++ b/configure.d/1_munmap.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012-2022 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
@@ -12,7 +12,7 @@ check() {
 	if compile_module $cur_name "vm_munmap(0, 0); MAP_PRIVATE;" "linux/mm.h"
 	then
 		echo $cur_name "1" >> $config_file_path
-	elif compile_module $cur_name "do_munmap(NULL, 0)" "linux/mm.h"
+	elif compile_module $cur_name "do_munmap(NULL, 0);" "linux/mm.h"
 	then
 		echo $cur_name "2" >> $config_file_path
 	elif compile_module $cur_name "vm_munmap(0, 0); MAP_PRIVATE;" "linux/mm.h"\

--- a/configure.d/1_queue_chunk_sectors.conf
+++ b/configure.d/1_queue_chunk_sectors.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012-2022 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
@@ -9,7 +9,7 @@
 check() {
 	cur_name=$(basename $2)
 	config_file_path=$1
-	if compile_module $cur_name "struct request_queue q;q.limits.chunk_sectors" "linux/blkdev.h"
+	if compile_module $cur_name "struct request_queue q;q.limits.chunk_sectors;" "linux/blkdev.h"
 	then
 		echo $cur_name "1" >> $config_file_path
 	else

--- a/configure.d/1_queue_flag_set.conf
+++ b/configure.d/1_queue_flag_set.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012-2022 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
@@ -9,7 +9,7 @@
 check() {
 	cur_name=$(basename $2)
 	config_file_path=$1
-	if compile_module $cur_name "blk_queue_flag_set(0, NULL)" "linux/blkdev.h"
+	if compile_module $cur_name "blk_queue_flag_set(0, NULL);" "linux/blkdev.h"
 	then
         echo $cur_name "1" >> $config_file_path
 	else

--- a/configure.d/1_timekeeping.conf
+++ b/configure.d/1_timekeeping.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012-2022 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
@@ -9,7 +9,7 @@
 check() {
 	cur_name=$(basename $2)
 	config_file_path=$1
-	if compile_module $cur_name "ktime_get_real_ts64(NULL)" "linux/ktime.h"
+	if compile_module $cur_name "ktime_get_real_ts64(NULL);" "linux/ktime.h"
 	then
 		echo $cur_name "1" >> $config_file_path
 	else

--- a/configure.d/1_wtlh.conf
+++ b/configure.d/1_wtlh.conf
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012-2022 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
@@ -9,7 +9,7 @@
 check() {
 	cur_name=$(basename $2)
 	config_file_path=$1
-	if compile_module $cur_name "struct bio b;b.bi_write_hint" "linux/bio.h"
+	if compile_module $cur_name "struct bio b;b.bi_write_hint;" "linux/bio.h"
 	then
 		echo $cur_name "1" >> $config_file_path
 	else


### PR DESCRIPTION
Since commit 51dc893fc1 every script must take care about adding a semicolon at
the end of compilable line of code

Signed-off-by: Michal Mielewczyk <michal.mielewczyk@intel.com>