### PR TITLE
RHEL8.5 kernel 4.18 support fix

### DIFF
--- a/configure.d/1_blk_queue_exit_for_rhel.conf
+++ b/configure.d/1_blk_queue_exit_for_rhel.conf
@@ -1,0 +1,68 @@
+#!/bin/bash
+#
+# Copyright(c) 2012-2022 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+. $(dirname $3)/conf_framework
+
+# RHEL8.5 kernel 4.18 subversion targeted for the workaround is 348.2.1.
+# The workaround is needed starting this version and up.
+LINUX_MAJOR_SINCE=4
+LINUX_MINOR_SINCE=18
+LINUX_SUB_SINCE=0
+RHEL_MAJOR_SINCE=348
+RHEL_MINOR_SINCE=2
+RHEL_SUB_SINCE=1
+
+check () {
+	cur_name=$(basename $2)
+	config_file_path=$1
+	LINUX_VERSION_CODE=$(get_define $cur_name "LINUX_VERSION_CODE" "generated/uapi/linux/version.h")
+	RHEL_RELEASE=$(get_define $cur_name "RHEL_RELEASE" "generated/uapi/linux/version.h")
+	LINUX_MAJOR=$((LINUX_VERSION_CODE >> 16 & 0xff))
+	LINUX_MINOR=$((LINUX_VERSION_CODE >> 8 & 0xff))
+	LINUX_SUB=$((LINUX_VERSION_CODE & 0xff))
+
+	if [ -z $RHEL_RELEASE ]; then
+		echo $cur_name "2" >> $config_file_path; #not RHEL, no workaround needed
+	else
+		#it's RHEL, check versions to see if the workaround is needed
+
+		IFS=. read -a arr <<< $RHEL_RELEASE
+		RHEL_MAJOR=${arr[0]}
+		RHEL_MINOR=${arr[1]}
+		RHEL_SUB=${arr[2]}
+
+		#check kernel and rhel version (major/minor/sub)
+		if [ "$LINUX_MAJOR" -eq "$LINUX_MAJOR_SINCE" ] &&
+		   [ "$LINUX_MINOR" -eq "$LINUX_MINOR_SINCE" ] &&
+		   [ "$LINUX_SUB"   -eq "$LINUX_SUB_SINCE" ] &&
+		   [ "$RHEL_MAJOR"  -ge "$RHEL_MAJOR_SINCE" ] &&
+		   [ "$RHEL_MINOR"  -ge "$RHEL_MINOR_SINCE" ] &&
+		   [ "$RHEL_SUB"    -ge "$RHEL_SUB_SINCE" ]
+		then
+			echo $cur_name "1" >> $config_file_path; #workaround needed
+		else
+			echo $cur_name "2" >> $config_file_path; #no workaround needed
+		fi
+	fi
+
+}
+
+apply() {
+	case "$1" in
+	"1")
+		add_define "cas_blk_queue_exit(bvol) \
+			percpu_ref_put(&(casdisk_functions.casdsk_exp_obj_get_queue(bvol->dsk)->q_usage_counter) );
+		"
+		;;
+	"2")
+		add_define "cas_blk_queue_exit(bvol) (void)bvol;"
+		;;
+	*)
+		exit 1
+	esac
+}
+
+conf_run $@

--- a/configure.d/conf_framework
+++ b/configure.d/conf_framework
@@ -97,7 +97,7 @@ EOM
 
 	rm -Rf $test_module_dir
 
-	grep -Pom 1 "note:.*$define_name .*" $test_module_log | cut -d' ' -f 5- | tr -d '"'
+	grep -Pom 1 "note:.*$define_name .*" $test_module_log | sed 's/[^0-9.]*//g'
 	local ret=$?
 
 	rm -f $test_module_log

--- a/modules/cas_cache/context.h
+++ b/modules/cas_cache/context.h
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012-2022 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 
@@ -19,6 +19,11 @@ struct bio_vec_iter {
 };
 
 struct blk_data {
+	/**
+	 * @brief bd_object for accessing request queue. Workaround for RHEL8.5
+	 */
+	struct bd_object *bvol;
+
 	/**
 	 * @brief Atomic counter for core device
 	 */


### PR DESCRIPTION
This patch adds support for RHEL8.5 with kernel 4.18.0.348.2.1.el8 and
later.

Additional request queue operations added for these kernels.
Configure scripts added/updated.

Fixes #1278

Signed-off-by: Krzysztof Majzerowicz-Jaszcz <krzysztof.majzerowicz-jaszcz@intel.com>