### PR TITLE
Rework for RHEL8.5

### DIFF
--- a/configure.d/1_blk_queue_exit_workaround_for_rhel.conf
+++ b/configure.d/1_blk_queue_exit_workaround_for_rhel.conf
@@ -6,14 +6,14 @@
 
 . $(dirname $3)/conf_framework
 
-# RHEL8.5 kernel 4.18 subversion targeted for the workaround is 348.2.1.
+# RHEL8.5 kernel 4.18 subversion targeted for the workaround is 348.7.1.
 # The workaround is needed starting this version and up.
-LINUX_MAJOR_SINCE=4
-LINUX_MINOR_SINCE=18
-LINUX_SUB_SINCE=0
-RHEL_MAJOR_SINCE=348
-RHEL_MINOR_SINCE=2
-RHEL_SUB_SINCE=1
+QUEUE_PUT_WA_LINUX_MAJOR_SINCE=4
+QUEUE_PUT_WA_LINUX_MINOR_SINCE=18
+QUEUE_PUT_WA_LINUX_SUB_SINCE=0
+QUEUE_PUT_WA_RHEL_MAJOR_SINCE=348
+QUEUE_PUT_WA_RHEL_MINOR_SINCE=7
+QUEUE_PUT_WA_RHEL_SUB_SINCE=1
 
 check () {
 	cur_name=$(basename $2)
@@ -35,12 +35,12 @@ check () {
 		RHEL_SUB=${arr[2]}
 
 		#check kernel and rhel version (major/minor/sub)
-		if [ "$LINUX_MAJOR" -eq "$LINUX_MAJOR_SINCE" ] &&
-		   [ "$LINUX_MINOR" -eq "$LINUX_MINOR_SINCE" ] &&
-		   [ "$LINUX_SUB"   -eq "$LINUX_SUB_SINCE" ] &&
-		   [ "$RHEL_MAJOR"  -ge "$RHEL_MAJOR_SINCE" ] &&
-		   [ "$RHEL_MINOR"  -ge "$RHEL_MINOR_SINCE" ] &&
-		   [ "$RHEL_SUB"    -ge "$RHEL_SUB_SINCE" ]
+		if [ "$LINUX_MAJOR" -eq "$QUEUE_PUT_WA_LINUX_MAJOR_SINCE" ] &&
+		   [ "$LINUX_MINOR" -eq "$QUEUE_PUT_WA_LINUX_MINOR_SINCE" ] &&
+		   [ "$LINUX_SUB"   -eq "$QUEUE_PUT_WA_LINUX_SUB_SINCE" ] &&
+		   [ "$RHEL_MAJOR"  -ge "$QUEUE_PUT_WA_RHEL_MAJOR_SINCE" ] &&
+		   [ "$RHEL_MINOR"  -ge "$QUEUE_PUT_WA_RHEL_MINOR_SINCE" ] &&
+		   [ "$RHEL_SUB"    -ge "$QUEUE_PUT_WA_RHEL_SUB_SINCE" ]
 		then
 			echo $cur_name "1" >> $config_file_path; #workaround needed
 		else
@@ -53,12 +53,12 @@ check () {
 apply() {
 	case "$1" in
 	"1")
-		add_define "cas_blk_queue_exit(bvol) \
-			percpu_ref_put(&(casdisk_functions.casdsk_exp_obj_get_queue(bvol->dsk)->q_usage_counter) );
+		add_define "cas_blk_queue_exit(q) \
+			percpu_ref_put(&q->q_usage_counter);
 		"
 		;;
 	"2")
-		add_define "cas_blk_queue_exit(bvol) (void)bvol;"
+		add_define "cas_blk_queue_exit(q) "
 		;;
 	*)
 		exit 1

--- a/modules/cas_cache/context.h
+++ b/modules/cas_cache/context.h
@@ -20,11 +20,6 @@ struct bio_vec_iter {
 
 struct blk_data {
 	/**
-	 * @brief bd_object for accessing request queue. Workaround for RHEL8.5
-	 */
-	struct bd_object *bvol;
-
-	/**
 	 * @brief Atomic counter for core device
 	 */
 	atomic_t master_remaining;

--- a/modules/cas_cache/volume/vol_block_dev_top.c
+++ b/modules/cas_cache/volume/vol_block_dev_top.c
@@ -182,7 +182,6 @@ static void blkdev_defer_bio(struct bd_object *bvol, struct bio *bio,
 	if (!context) {
 		CAS_BIO_ENDIO(bio, CAS_BIO_BISIZE(bio),
 			CAS_ERRNO_TO_BLK_STS(-ENOMEM));
-		cas_blk_queue_exit(bvol);
 		return;
 	}
 
@@ -207,7 +206,6 @@ static void blkdev_complete_data_master(struct blk_data *master, int error)
 	result = map_cas_err_to_generic(master->error);
 	CAS_BIO_ENDIO(master->bio, master->master_size,
 			CAS_ERRNO_TO_BLK_STS(result));
-	cas_blk_queue_exit(master->bvol);
 
 	cas_free_blk_data(master);
 }
@@ -277,7 +275,6 @@ static int blkdev_handle_data_single(struct bd_object *bvol, struct bio *bio,
 		data->bio = master_ctx->bio;
 		data->master_size = master_ctx->master_size;
 		data->start_time = master_ctx->start_time;
-		data->bvol = bvol;
 		master_ctx->data = data;
 	}
 
@@ -308,7 +305,6 @@ static void blkdev_handle_data(struct bd_object *bvol, struct bio *bio)
 			CAS_BIO_OP_FLAGS_FORMAT "\n",  CAS_BIO_OP_FLAGS(bio));
 		CAS_BIO_ENDIO(bio, CAS_BIO_BISIZE(bio),
 				CAS_ERRNO_TO_BLK_STS(-EINVAL));
-		cas_blk_queue_exit(bvol);
 		return;
 	}
 
@@ -334,26 +330,20 @@ static void blkdev_handle_data(struct bd_object *bvol, struct bio *bio)
 	return;
 
 err:
-	if (split != bio) {
+	if (split != bio)
 		bio_put(split);
-	}
-	if (master_ctx.data) {
+	if (master_ctx.data)
 		blkdev_complete_data_master(master_ctx.data, error);
-	}
-	else {
+	else
 		CAS_BIO_ENDIO(bio, CAS_BIO_BISIZE(bio), CAS_ERRNO_TO_BLK_STS(error));
-		cas_blk_queue_exit(bvol);
-	}
 }
 
 static void blkdev_complete_discard(struct ocf_io *io, int error)
 {
 	struct bio *bio = io->priv1;
-	struct bd_object *bvol = io->priv2;
 	int result = map_cas_err_to_generic(error);
 
 	CAS_BIO_ENDIO(bio, CAS_BIO_BISIZE(bio), CAS_ERRNO_TO_BLK_STS(result));
-	cas_blk_queue_exit(bvol);
 	ocf_io_put(io);
 }
 
@@ -371,11 +361,10 @@ static void blkdev_handle_discard(struct bd_object *bvol, struct bio *bio)
 		CAS_PRINT_RL(KERN_CRIT
 			"Out of memory. Ending IO processing.\n");
 		CAS_BIO_ENDIO(bio, CAS_BIO_BISIZE(bio), CAS_ERRNO_TO_BLK_STS(-ENOMEM));
-		cas_blk_queue_exit(bvol);
 		return;
 	}
 
-	ocf_io_set_cmpl(io, bio, bvol, blkdev_complete_discard);
+	ocf_io_set_cmpl(io, bio, NULL, blkdev_complete_discard);
 
 	ocf_volume_submit_discard(io);
 }
@@ -399,7 +388,6 @@ static void blkdev_complete_flush(struct ocf_io *io, int error)
 	if (CAS_BIO_BISIZE(bio) == 0 || error) {
 		CAS_BIO_ENDIO(bio, CAS_BIO_BISIZE(bio),
 				CAS_ERRNO_TO_BLK_STS(result));
-		cas_blk_queue_exit(bvol);
 		return;
 	}
 
@@ -422,7 +410,6 @@ static void blkdev_handle_flush(struct bd_object *bvol, struct bio *bio)
 		CAS_PRINT_RL(KERN_CRIT
 			"Out of memory. Ending IO processing.\n");
 		CAS_BIO_ENDIO(bio, CAS_BIO_BISIZE(bio), CAS_ERRNO_TO_BLK_STS(-ENOMEM));
-		cas_blk_queue_exit(bvol);
 		return;
 	}
 
@@ -444,7 +431,6 @@ static void blkdev_submit_bio(struct bd_object *bvol, struct bio *bio)
 	if (blkdev_can_hndl_bio(bio)) {
 		CAS_BIO_ENDIO(bio, CAS_BIO_BISIZE(bio),
 				CAS_ERRNO_TO_BLK_STS(-ENOTSUPP));
-		cas_blk_queue_exit(bvol);
 		return;
 	}
 

--- a/modules/cas_disk/exp_obj.c
+++ b/modules/cas_disk/exp_obj.c
@@ -186,7 +186,9 @@ static MAKE_RQ_RET_TYPE _casdsk_exp_obj_submit_bio(struct bio *bio)
 static MAKE_RQ_RET_TYPE _casdsk_exp_obj_make_rq_fn(struct request_queue *q,
 						 struct bio *bio)
 {
-	return _casdsk_exp_obj_submit_bio(bio);
+	_casdsk_exp_obj_submit_bio(bio);
+	cas_blk_queue_exit(q);
+	KRETURN(0);
 }
 
 static int _casdsk_del_partitions(struct casdsk_disk *dsk)


### PR DESCRIPTION
Rework for RHEL8.5 compatibility to avoid potential bug of exiting queue
after IO completion on a different CPU.

Targeted RHEL kernel version corrected.

Signed-off-by: Krzysztof Majzerowicz-Jaszcz <krzysztof.majzerowicz-jaszcz@intel.com>