### PR TITLE
Fix for a build failure for Ubuntu 18.04 kernel 4.15

### DIFF
--- a/configure.d/1_bio_split.conf
+++ b/configure.d/1_bio_split.conf
@@ -9,12 +9,15 @@
 check() {
 	cur_name=$(basename $2)
 	config_file_path=$1
-    if compile_module $cur_name "bio_split(NULL, 0, 0, 0);" "linux/bio.h"
+    if compile_module $cur_name "bio_split(NULL, 0, 0, &fs_bio_set);" "linux/bio.h"
     then
         echo $cur_name "1" >> $config_file_path
+    elif compile_module $cur_name "bio_split(NULL, 0, 0, fs_bio_set);" "linux/bio.h"
+    then
+	echo $cur_name "2" >> $config_file_path
     elif compile_module $cur_name "bio_split(NULL, 0);" "linux/bio.h"
     then
-        echo $cur_name "2" >> $config_file_path
+        echo $cur_name "3" >> $config_file_path
     else
         echo $cur_name "X" >> $config_file_path
     fi
@@ -29,6 +32,12 @@ apply() {
         return bio_split(bio, sectors, GFP_NOIO, &fs_bio_set);
     }" ;;
     "2")
+        add_function "
+    static inline struct bio *cas_bio_split(struct bio *bio, int sectors)
+    {
+	return bio_split(bio, sectors, GFP_NOIO, fs_bio_set);
+    }" ;;
+    "3")
         add_function "
     static inline struct bio *cas_bio_split(struct bio *bio, int sectors)
     {


### PR DESCRIPTION
This patch fixes the problem of fs_bio_set being defined as a pointer in
kernels before 4.18, which results in build failure.

Fixes #1312

Signed-off-by: Krzysztof Majzerowicz-Jaszcz <krzysztof.majzerowicz-jaszcz@intel.com>