### PR TITLE
Tests marking clean up (os-dependend and skipped)

### DIFF
--- a/test/functional/tests/cache_ops/test_multistream_seq_cutoff.py
+++ b/test/functional/tests/cache_ops/test_multistream_seq_cutoff.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020-2022 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 import os
@@ -23,6 +23,7 @@ random_thresholds = random.sample(range(1028, 1024 ** 2, 4), 3)
 random_stream_numbers = random.sample(range(2, 128), 3)
 
 
+@pytest.mark.os_dependent
 @pytest.mark.parametrizex("streams_number", [1, 128] + random_stream_numbers)
 @pytest.mark.parametrizex("threshold",
                           [Size(1, Unit.MebiByte), Size(1, Unit.GibiByte)]
@@ -130,6 +131,7 @@ def run_dd(target_path, count, seek):
     TestRun.LOGGER.info(f"dd command:\n{dd}")
 
 
+@pytest.mark.os_dependent
 @pytest.mark.parametrizex("streams_seq_rand", [(64, 64), (64, 192)])
 @pytest.mark.require_disk("cache", DiskTypeSet([DiskType.optane, DiskType.nand]))
 @pytest.mark.require_disk("core", DiskTypeLowerThan("cache"))
@@ -185,6 +187,7 @@ def test_multistream_seq_cutoff_stress_raw(streams_seq_rand):
             TestRun.LOGGER.info(f"{core.get_statistics()}")
 
 
+@pytest.mark.os_dependent
 @pytest.mark.parametrizex("streams_seq_rand", [(64, 64), (64, 192)])
 @pytest.mark.parametrizex("filesystem", Filesystem)
 @pytest.mark.parametrizex("cache_mode", CacheMode.with_traits(CacheModeTrait.LazyWrites))

--- a/test/functional/tests/ci/test_incremental_load_ci.py
+++ b/test/functional/tests/ci/test_incremental_load_ci.py
@@ -15,6 +15,7 @@ from test_utils.size import Size, Unit
 
 
 @pytest.mark.CI
+@pytest.mark.os_dependent
 @pytest.mark.require_disk("cache", DiskTypeSet([DiskType.optane, DiskType.nand]))
 @pytest.mark.require_disk("core", DiskTypeLowerThan("cache"))
 def test_incremental_load_basic():
@@ -68,6 +69,7 @@ def test_incremental_load_basic():
 
 
 @pytest.mark.CI
+@pytest.mark.os_dependent
 @pytest.mark.require_disk("cache", DiskTypeSet([DiskType.optane, DiskType.nand]))
 @pytest.mark.require_disk("core", DiskTypeLowerThan("cache"))
 def test_incremental_load_hidden_core():

--- a/test/functional/tests/ci/test_simulation_startup.py
+++ b/test/functional/tests/ci/test_simulation_startup.py
@@ -16,6 +16,7 @@ from test_utils.size import Size, Unit
 
 
 @pytest.mark.CI
+@pytest.mark.os_dependent
 @pytest.mark.require_disk("cache", DiskTypeSet([DiskType.optane, DiskType.nand]))
 @pytest.mark.require_disk("core", DiskTypeLowerThan("cache"))
 def test_simulation_startup_from_config():

--- a/test/functional/tests/failover_standby/test_failover_advanced.py
+++ b/test/functional/tests/failover_standby/test_failover_advanced.py
@@ -76,9 +76,10 @@ def timed_async_power_cycle():
         )
 
 
+@pytest.mark.os_dependent_standby_mode_specific
+@pytest.mark.multidut(2)
 @pytest.mark.require_disk("cache_dev", DiskTypeSet([DiskType.optane]))
 @pytest.mark.require_disk("core_dev", DiskTypeSet([DiskType.nand]))
-@pytest.mark.multidut(2)
 @pytest.mark.parametrize("cache_mode", CacheMode.with_traits(CacheModeTrait.LazyWrites))
 @pytest.mark.parametrize("cls", [CacheLineSize.LINE_4KiB, CacheLineSize.LINE_64KiB])
 @pytest.mark.parametrize("cleaning_policy", [c for c in CleaningPolicy if c != CleaningPolicy.nop])
@@ -336,9 +337,10 @@ def test_failover_during_background_cleaning(cache_mode, cls, cleaning_policy, n
             TestRun.executor.wait_for_connection()
 
 
+@pytest.mark.os_dependent_standby_mode_specific
+@pytest.mark.multidut(2)
 @pytest.mark.require_disk("cache_dev", DiskTypeSet([DiskType.optane]))
 @pytest.mark.require_disk("core_dev", DiskTypeSet([DiskType.nand]))
-@pytest.mark.multidut(2)
 @pytest.mark.parametrize("cache_mode", CacheMode.with_traits(CacheModeTrait.LazyWrites))
 @pytest.mark.parametrize("cls", [CacheLineSize.LINE_4KiB, CacheLineSize.LINE_64KiB])
 @pytest.mark.parametrize("num_iterations", [2])
@@ -586,9 +588,10 @@ def test_failover_during_dirty_flush(cache_mode, cls, num_iterations):
             TestRun.executor.wait_for_connection()
 
 
+@pytest.mark.os_dependent_standby_mode_specific
+@pytest.mark.multidut(2)
 @pytest.mark.require_disk("cache_dev", DiskTypeSet([DiskType.optane]))
 @pytest.mark.require_disk("core_dev", DiskTypeSet([DiskType.nand]))
-@pytest.mark.multidut(2)
 @pytest.mark.parametrize("cache_mode", CacheMode.with_any_trait(CacheModeTrait.InsertRead))
 @pytest.mark.parametrize("cls", [CacheLineSize.LINE_4KiB, CacheLineSize.LINE_64KiB])
 @pytest.mark.parametrize("cleaning_policy", CleaningPolicy)
@@ -872,9 +875,10 @@ def test_failover_during_io_with_eviction(cache_mode, cls, cleaning_policy, num_
             TestRun.executor.wait_for_connection()
 
 
+@pytest.mark.os_dependent_standby_mode_specific
+@pytest.mark.multidut(2)
 @pytest.mark.require_disk("cache_dev", DiskTypeSet([DiskType.optane]))
 @pytest.mark.require_disk("core_dev", DiskTypeSet([DiskType.nand]))
-@pytest.mark.multidut(2)
 @pytest.mark.parametrize("cls", [CacheLineSize.LINE_4KiB, CacheLineSize.LINE_64KiB])
 @pytest.mark.parametrize("cleaning_policy", [c for c in CleaningPolicy if c != CleaningPolicy.alru])
 @pytest.mark.parametrize("num_iterations", [1])

--- a/test/functional/tests/incremental_load/test_core_pool.py
+++ b/test/functional/tests/incremental_load/test_core_pool.py
@@ -71,6 +71,7 @@ def test_attach_core_pool():
         cache.stop()
 
 
+@pytest.mark.os_dependent
 @pytest.mark.require_disk("cache", DiskTypeSet([DiskType.optane, DiskType.nand]))
 @pytest.mark.require_disk("core", DiskTypeLowerThan("cache"))
 def test_core_pool_exclusive_open():

--- a/test/functional/tests/initialize/test_clean_reboot.py
+++ b/test/functional/tests/initialize/test_clean_reboot.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020-2022 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
@@ -20,6 +20,7 @@ from test_utils.size import Size, Unit
 mount_point = "/mnt/test"
 
 
+@pytest.mark.os_dependent
 @pytest.mark.require_disk("cache", DiskTypeSet([DiskType.optane, DiskType.nand]))
 @pytest.mark.require_disk("core", DiskTypeLowerThan("cache"))
 @pytest.mark.parametrizex("cache_mode", CacheMode)

--- a/test/functional/tests/initialize/test_startup_init_config.py
+++ b/test/functional/tests/initialize/test_startup_init_config.py
@@ -155,6 +155,7 @@ def test_cas_init_with_changed_mode(cache_mode_pair):
         validate_cache(cache_mode_pair[1])
 
 
+@pytest.mark.os_dependent
 @pytest.mark.require_disk("cache", DiskTypeSet([DiskType.optane, DiskType.nand]))
 @pytest.mark.require_disk("core", DiskTypeSet([DiskType.hdd]))
 @pytest.mark.require_plugin("power_control")
@@ -259,6 +260,7 @@ def test_cas_startup_lazy():
             )
 
 
+@pytest.mark.os_dependent
 @pytest.mark.require_disk("cache", DiskTypeSet([DiskType.optane, DiskType.nand]))
 @pytest.mark.require_disk("core", DiskTypeSet([DiskType.hdd]))
 def test_cas_startup_negative_missing_core():
@@ -320,6 +322,7 @@ def test_cas_startup_negative_missing_core():
     InitConfig().create_default_init_config()
 
 
+@pytest.mark.os_dependent
 @pytest.mark.require_disk("cache", DiskTypeSet([DiskType.optane, DiskType.nand]))
 @pytest.mark.require_disk("core", DiskTypeSet([DiskType.hdd]))
 def test_cas_startup_negative_missing_cache():
@@ -381,6 +384,7 @@ def test_cas_startup_negative_missing_cache():
     InitConfig().create_default_init_config()
 
 
+@pytest.mark.os_dependent
 @pytest.mark.require_disk("cache", DiskTypeSet([DiskType.optane, DiskType.nand]))
 @pytest.mark.require_disk("core", DiskTypeSet([DiskType.hdd]))
 @pytest.mark.require_plugin("power_control")
@@ -485,6 +489,7 @@ def test_failover_config_startup():
             )
 
 
+@pytest.mark.os_dependent
 @pytest.mark.require_disk("cache", DiskTypeSet([DiskType.optane, DiskType.nand]))
 def test_failover_config_startup_negative():
     """

--- a/test/functional/tests/io/trim/test_trim.py
+++ b/test/functional/tests/io/trim/test_trim.py
@@ -171,6 +171,7 @@ def test_trim_propagation():
         cas_fio.run()
 
 
+@pytest.mark.os_dependent
 @pytest.mark.parametrizex("cache_mode", CacheMode.with_traits(CacheModeTrait.InsertWrite))
 @pytest.mark.parametrizex("filesystem", Filesystem)
 @pytest.mark.parametrizex("cleaning_policy", CleaningPolicy)

--- a/test/functional/tests/io/trim/test_trim_stress.py
+++ b/test/functional/tests/io/trim/test_trim_stress.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020-2022 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
@@ -14,6 +14,7 @@ from test_tools.disk_utils import Filesystem
 from test_utils.size import Size, Unit
 
 
+@pytest.mark.os_dependent
 @pytest.mark.require_disk("cache", DiskTypeSet([DiskType.optane, DiskType.nand, DiskType.sata]))
 @pytest.mark.require_disk("core", DiskTypeSet([DiskType.optane, DiskType.nand, DiskType.sata]))
 @pytest.mark.parametrizex("cache_mode", CacheMode)

--- a/test/functional/tests/io_class/test_io_class_occupancy.py
+++ b/test/functional/tests/io_class/test_io_class_occupancy.py
@@ -28,6 +28,7 @@ from tests.io_class.io_class_common import (
 )
 
 
+@pytest.mark.os_dependent
 @pytest.mark.require_disk("cache", DiskTypeSet([DiskType.optane, DiskType.nand]))
 @pytest.mark.require_disk("core", DiskTypeLowerThan("cache"))
 @pytest.mark.parametrize("io_size_multiplication", [0.5, 2])
@@ -157,6 +158,7 @@ def test_io_class_occupancy_directory_write(io_size_multiplication, cache_mode):
                 )
 
 
+@pytest.mark.os_dependent
 @pytest.mark.require_disk("cache", DiskTypeSet([DiskType.optane, DiskType.nand]))
 @pytest.mark.require_disk("core", DiskTypeLowerThan("cache"))
 @pytest.mark.parametrize("io_size_multiplication", [0.5, 2])
@@ -290,6 +292,7 @@ def test_io_class_occupancy_directory_read(io_size_multiplication):
                 )
 
 
+@pytest.mark.os_dependent
 @pytest.mark.require_disk("cache", DiskTypeSet([DiskType.optane, DiskType.nand]))
 @pytest.mark.require_disk("core", DiskTypeLowerThan("cache"))
 def test_ioclass_occupancy_sum_cache():

--- a/test/functional/tests/io_class/test_io_class_occupancy_load.py
+++ b/test/functional/tests/io_class/test_io_class_occupancy_load.py
@@ -28,6 +28,7 @@ from tests.io_class.io_class_common import (
 )
 
 
+@pytest.mark.os_dependent
 @pytest.mark.require_disk("cache", DiskTypeSet([DiskType.optane, DiskType.nand]))
 @pytest.mark.require_disk("core", DiskTypeLowerThan("cache"))
 def test_ioclass_occupancy_load():

--- a/test/functional/tests/io_class/test_io_class_occupancy_repart.py
+++ b/test/functional/tests/io_class/test_io_class_occupancy_repart.py
@@ -27,6 +27,7 @@ from tests.io_class.io_class_common import (
 )
 
 
+@pytest.mark.os_dependent
 @pytest.mark.require_disk("cache", DiskTypeSet([DiskType.optane, DiskType.nand]))
 @pytest.mark.require_disk("core", DiskTypeLowerThan("cache"))
 @pytest.mark.parametrize("io_class_size_multiplication", [0.5, 1])

--- a/test/functional/tests/io_class/test_io_class_occupancy_resize.py
+++ b/test/functional/tests/io_class/test_io_class_occupancy_resize.py
@@ -23,6 +23,7 @@ from tests.io_class.io_class_common import (
 )
 
 
+@pytest.mark.os_dependent
 @pytest.mark.require_disk("cache", DiskTypeSet([DiskType.optane, DiskType.nand]))
 @pytest.mark.require_disk("core", DiskTypeLowerThan("cache"))
 @pytest.mark.parametrizex("cache_line_size", CacheLineSize)

--- a/test/functional/tests/io_class/test_io_class_purge.py
+++ b/test/functional/tests/io_class/test_io_class_purge.py
@@ -19,6 +19,7 @@ from test_utils.size import Unit, Size
 from tests.io_class.io_class_common import prepare, mountpoint, ioclass_config_path
 
 
+@pytest.mark.os_dependent
 @pytest.mark.require_disk("cache", DiskTypeSet([DiskType.optane, DiskType.nand]))
 @pytest.mark.require_disk("core", DiskTypeLowerThan("cache"))
 def test_ioclass_usage_sum():

--- a/test/functional/tests/io_class/test_io_class_wlth.py
+++ b/test/functional/tests/io_class/test_io_class_wlth.py
@@ -15,6 +15,7 @@ from test_utils.size import Unit, Size
 from tests.io_class.io_class_common import prepare
 
 
+@pytest.mark.os_dependent
 @pytest.mark.require_disk("cache", DiskTypeSet([DiskType.optane, DiskType.nand]))
 @pytest.mark.require_disk("core", DiskTypeLowerThan("cache"))
 def test_ioclass_wlth():

--- a/test/functional/tests/lazy_writes/cleaning_policy/test_acp.py
+++ b/test/functional/tests/lazy_writes/cleaning_policy/test_acp.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020-2022 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
@@ -278,6 +278,7 @@ def test_acp_param_flush_max_buffers(cache_line_size, cache_mode):
         casadm.stop_all_caches()
 
 
+@pytest.mark.os_dependent
 @pytest.mark.parametrizex(
     "cache_line_size",
     [CacheLineSize.LINE_4KiB, CacheLineSize.LINE_16KiB, CacheLineSize.LINE_64KiB],

--- a/test/functional/tests/lazy_writes/recovery/test_recovery_all_options.py
+++ b/test/functional/tests/lazy_writes/recovery/test_recovery_all_options.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019-2022 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
@@ -29,6 +29,7 @@ pattern = "0xabcd"
 other_pattern = "0x0000"
 
 
+@pytest.mark.os_dependent
 @pytest.mark.require_disk("cache", DiskTypeSet([DiskType.optane, DiskType.nand]))
 @pytest.mark.require_disk("core", DiskTypeLowerThan("cache"))
 @pytest.mark.parametrizex("cache_mode", CacheMode.with_traits(CacheModeTrait.LazyWrites))

--- a/test/functional/tests/lazy_writes/recovery/test_recovery_flush_reset.py
+++ b/test/functional/tests/lazy_writes/recovery/test_recovery_flush_reset.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019-2022 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
@@ -24,6 +24,7 @@ mount_point = "/mnt"
 test_file_size = Size(4.5, Unit.GibiByte)
 
 
+@pytest.mark.os_dependent
 @pytest.mark.require_disk("cache", DiskTypeSet([DiskType.optane, DiskType.nand]))
 @pytest.mark.require_disk("core", DiskTypeLowerThan("cache"))
 @pytest.mark.parametrizex("cache_mode", CacheMode.with_traits(CacheModeTrait.LazyWrites))
@@ -100,6 +101,7 @@ def test_recovery_flush_reset_raw(cache_mode):
             pass
 
 
+@pytest.mark.os_dependent
 @pytest.mark.require_disk("cache", DiskTypeSet([DiskType.optane, DiskType.nand]))
 @pytest.mark.require_disk("core", DiskTypeLowerThan("cache"))
 @pytest.mark.parametrizex("cache_mode", CacheMode.with_traits(CacheModeTrait.LazyWrites))

--- a/test/functional/tests/misc/test_weak_modules.py
+++ b/test/functional/tests/misc/test_weak_modules.py
@@ -7,6 +7,8 @@
 import os
 import re
 
+import pytest
+
 from api.cas.installer import clean_opencas_repo, rsync_opencas_sources
 from core.test_run import TestRun
 from test_tools.fs_utils import (
@@ -22,6 +24,7 @@ modules_links_dir = "/lib/modules/$(uname -r)/weak-updates/block/opencas"
 modules_names = ["cas_cache.ko"]
 
 
+@pytest.mark.os_dependent
 def test_weak_modules():
     """
     title: Test for weak-modules symlinks handling.

--- a/test/functional/tests/performance/test_100p_hits.py
+++ b/test/functional/tests/performance/test_100p_hits.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020-2022 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
@@ -22,6 +22,7 @@ from test_utils.output import CmdException
 from storage_devices.disk import DiskTypeSet, DiskTypeLowerThan, DiskType
 
 
+@pytest.mark.os_dependent
 @pytest.mark.performance()
 @pytest.mark.require_disk("cache", DiskTypeSet([DiskType.optane, DiskType.nand]))
 @pytest.mark.require_disk("core", DiskTypeLowerThan("cache"))

--- a/test/functional/tests/security/test_compilation_flags.py
+++ b/test/functional/tests/security/test_compilation_flags.py
@@ -1,16 +1,19 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019-2022 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
 import os
 import re
 
+import pytest
+
 from core.test_run import TestRun
 from test_tools.fs_utils import Permissions, PermissionsUsers, PermissionSign
 from test_utils.filesystem.fs_item import FsItem
 
 
+@pytest.mark.os_dependent
 def test_checksec():
     """
         title: Checking defenses enabled compilation flags.

--- a/test/functional/tests/stress/test_kedr.py
+++ b/test/functional/tests/stress/test_kedr.py
@@ -43,6 +43,7 @@ def unload_modules():
     os_utils.mount_debugfs()
 
 
+@pytest.mark.skip(reason="kedr not supported")
 @pytest.mark.parametrize("module", cas_module.CasModule)
 def test_kedr_memleak_load_cas_module(module, unload_modules, install_kedr):
     """
@@ -70,6 +71,7 @@ def test_kedr_memleak_load_cas_module(module, unload_modules, install_kedr):
         Kedr.stop()
 
 
+@pytest.mark.skip(reason="kedr not supported")
 @pytest.mark.parametrize("module", cas_module.CasModule)
 def test_kedr_fsim_load_cas_module(module, unload_modules, install_kedr):
     """
@@ -95,6 +97,7 @@ def test_kedr_fsim_load_cas_module(module, unload_modules, install_kedr):
         Kedr.stop()
 
 
+@pytest.mark.skip(reason="kedr not supported")
 @pytest.mark.parametrize("module", cas_module.CasModule)
 @pytest.mark.require_disk("cache", DiskTypeSet([DiskType.optane, DiskType.nand]))
 @pytest.mark.require_disk("core", DiskTypeLowerThan("cache"))
@@ -149,6 +152,7 @@ def test_kedr_start_cache(module, unload_modules, install_kedr):
         Kedr.stop()
 
 
+@pytest.mark.skip(reason="kedr not supported")
 @pytest.mark.os_dependent
 @pytest.mark.parametrize("module", cas_module.CasModule)
 @pytest.mark.require_disk("cache", DiskTypeSet([DiskType.optane, DiskType.nand]))
@@ -214,6 +218,7 @@ def test_kedr_basic_io_raw(module, unload_modules, install_kedr):
         Kedr.stop()
 
 
+@pytest.mark.skip(reason="kedr not supported")
 @pytest.mark.os_dependent
 @pytest.mark.parametrize("module", cas_module.CasModule)
 @pytest.mark.require_disk("cache", DiskTypeSet([DiskType.optane, DiskType.nand]))

--- a/test/functional/tests/stress/test_kedr.py
+++ b/test/functional/tests/stress/test_kedr.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020-2021 Intel Corporation
+# Copyright(c) 2020-2022 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 


### PR DESCRIPTION
Marking all os-dependent tests with proper mark: @pytest.mark.os_dependent.

Mark: @pytest.mark.os_dependent_standby_mode_specific - means that those tests should be run only for scopes/clients which are using standby mode functionality (because of their complexity).

Adding mark: @pytest.mark.skip(reason="kedr not supported") - for kedr tests.