### PR TITLE
Remove python3-packaging from dependencies

### DIFF
--- a/test/functional/requirements.txt
+++ b/test/functional/requirements.txt
@@ -1,4 +1,5 @@
 attotime>=0.2.0
-schema==0.7.2
-recordclass>=0.8.4
+packaging>=20.3
 pytest-asyncio>=0.14.0
+recordclass>=0.8.4
+schema==0.7.2

--- a/tools/pckgen.d/deb/debian/control
+++ b/tools/pckgen.d/deb/debian/control
@@ -9,7 +9,7 @@ Vcs-Git: <CAS_GIT>
 
 Package: <CAS_NAME>
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, python3, python3-packaging, python3-yaml,
+Depends: ${shlibs:Depends}, ${misc:Depends}, python3, python3-yaml,
  <CAS_NAME>-modules (= <CAS_VERSION>-1)
 Description: Open Cache Acceleration Software
  Open Cache Acceleration Software (Open CAS) is an open source project

--- a/tools/pckgen.d/rpm/CAS_NAME.spec
+++ b/tools/pckgen.d/rpm/CAS_NAME.spec
@@ -27,7 +27,7 @@ URL:        <CAS_HOMEPAGE>
 Source0:    https://github.com/Open-CAS/open-cas-linux/releases/download/v%{version}/%{name}-%{version}.tar.gz
 Packager:   <PACKAGE_MAINTAINER>
 BuildRequires:  coreutils, gawk, gcc, kernel-devel, kernel-headers, make
-Requires:   <CAS_NAME>-modules-%{version}, python3, sed, python3-packaging, python3-PyYAML
+Requires:   <CAS_NAME>-modules-%{version}, python3, sed, python3-PyYAML
 %description
 Open Cache Acceleration Software (Open CAS) is an open source project
 encompassing block caching software libraries, adapters, tools and more.


### PR DESCRIPTION
Remove python3-packaging from OCL installation dependencies.
Instead add this package to python requirements.txt file as it is needed for testing environment.

Signed-off-by: Rafal Stefanowski <rafal.stefanowski@intel.com>