### PR TITLE
configure: fix rhel 8.5 workaround check

### DIFF
--- a/configure.d/1_blk_queue_exit_workaround_for_rhel.conf
+++ b/configure.d/1_blk_queue_exit_workaround_for_rhel.conf
@@ -30,9 +30,9 @@ check () {
 		#it's RHEL, check versions to see if the workaround is needed
 
 		IFS=. read -a arr <<< $RHEL_RELEASE
-		RHEL_MAJOR=${arr[0]}
-		RHEL_MINOR=${arr[1]}
-		RHEL_SUB=${arr[2]}
+		RHEL_MAJOR="${arr[0]:=0}"
+		RHEL_MINOR="${arr[1]:=0}"
+		RHEL_SUB="${arr[2]:=0}"
 
 		#check kernel and rhel version (major/minor/sub)
 		if [ "$LINUX_MAJOR" -eq "$QUEUE_PUT_WA_LINUX_MAJOR_SINCE" ] &&


### PR DESCRIPTION
In case the installed kernel doesn't have a minor version number the script fails. Assigning default value removes this error.

Signed-off-by: Michal Mielewczyk <michal.mielewczyk@intel.com>