### PR TITLE
tests: add multilevel cache test

### DIFF
--- a/test/functional/tests/volumes/common.py
+++ b/test/functional/tests/volumes/common.py
@@ -1,0 +1,42 @@
+#
+# Copyright(c) 2022 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+#
+from test_tools import fs_utils
+from core.test_run import TestRun
+from test_utils.size import Size, Unit
+
+test_file_size = Size(500, Unit.KiloByte)
+
+
+def create_files_with_md5sums(destination_path, files_count):
+    md5sums = list()
+    for i in range(0, files_count):
+        temp_file = f"/tmp/file{i}"
+        destination_file = f"{destination_path}/file{i}"
+
+        test_file = fs_utils.create_random_test_file(temp_file, test_file_size)
+        test_file.copy(destination_file, force=True)
+
+        md5sums.append(test_file.md5sum())
+
+    TestRun.LOGGER.info(f"Files created and copied to core successfully.")
+    return md5sums
+
+
+def compare_md5sums(md5_sums_source, files_to_check_path, copy_to_tmp=False):
+    md5_sums_elements = len(md5_sums_source)
+
+    for i in range(md5_sums_elements):
+        file_to_check_path = f"{files_to_check_path}/file{i}"
+        file_to_check = fs_utils.parse_ls_output(fs_utils.ls_item(file_to_check_path))[0]
+
+        if copy_to_tmp:
+            file_to_check_path = f"{files_to_check_path}/filetmp"
+            file_to_check.copy(file_to_check_path, force=True)
+            file_to_check = fs_utils.parse_ls_output(fs_utils.ls_item(file_to_check_path))[0]
+
+        if md5_sums_source[i] != file_to_check.md5sum():
+            TestRun.fail(f"Source and target files {file_to_check_path} checksums are different.")
+
+    TestRun.LOGGER.info(f"Successful verification, md5sums match.")

--- a/test/functional/tests/volumes/test_multilevel_cache_3.py
+++ b/test/functional/tests/volumes/test_multilevel_cache_3.py
@@ -1,0 +1,74 @@
+#
+# Copyright(c) 2022 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+
+import pytest
+from storage_devices.disk import DiskType, DiskTypeSet, DiskTypeLowerThan
+from core.test_run import TestRun
+from api.cas.cache import CacheMode, casadm
+from test_utils.size import Size, Unit
+from test_tools.disk_utils import Filesystem
+from .common import create_files_with_md5sums, compare_md5sums
+
+mount_point = "/mnt/test"
+
+
+@pytest.mark.require_disk("cache_1", DiskTypeSet([DiskType.optane, DiskType.nand]))
+@pytest.mark.require_disk("cache_2", DiskTypeSet([DiskType.optane, DiskType.nand]))
+@pytest.mark.require_disk("core_1", DiskTypeLowerThan("cache_1"))
+@pytest.mark.require_disk("cache_3", DiskTypeSet([DiskType.hdd]))
+def test_multilevel_cache_3():
+    """
+    title:
+      Test multilevel cache.
+    description:
+      CAS Linux is able to use 3-level cache in different cache mode and remove it gracefully.
+    pass_criteria:
+      - Succesfully created 3-level cache.
+      - Succesfully mounted filesystem on CAS device.
+      - md5 sums are correct.
+    """
+    with TestRun.step("Prepare devices"):
+        core_dev_1 = TestRun.disks["core_1"]
+
+        cache_hdd = TestRun.disks["cache_3"]
+        cache_hdd.create_partitions([Size(3.2, Unit.GibiByte)])
+        cache_hdd = cache_hdd.partitions[0]
+
+        cache_dev_1 = TestRun.disks["cache_1"]
+        cache_dev_1.create_partitions([Size(3.2, Unit.GibiByte)])
+        cache_dev_1 = cache_dev_1.partitions[0]
+
+        cache_dev_2 = TestRun.disks["cache_2"]
+        cache_dev_2.create_partitions([Size(3.2, Unit.GibiByte)])
+        cache_dev_2 = cache_dev_2.partitions[0]
+
+    with TestRun.step("Create cache in WT mode and add core to it"):
+        cache_WT = casadm.start_cache(cache_dev=cache_dev_1, cache_mode=CacheMode.WT)
+        core_WT = cache_WT.add_core(core_dev=core_dev_1)
+
+    with TestRun.step("Create second layer cache in WB mode"):
+        cache_WB = casadm.start_cache(cache_dev=cache_dev_2, cache_mode=CacheMode.WB)
+
+    with TestRun.step("Add first CAS device by setting exported object as core to second layer"):
+        core_WB = cache_WB.add_core(core_WT)
+
+    with TestRun.step("Create third layer cache in WA mode"):
+        cache_WA = casadm.start_cache(cache_dev=cache_hdd, cache_mode=CacheMode.WA)
+
+    with TestRun.step("Add second CAS device by setting exported object as core to third layer"):
+        core = cache_WA.add_core(core_WB)
+
+    with TestRun.step("Create and mount filesystem on third CAS device"):
+        core.create_filesystem(Filesystem.ext3, blocksize=int(Size(1, Unit.Blocks4096)))
+        core.mount(mount_point)
+
+    with TestRun.step("Create files and copy them to mounted directory"):
+        md5_sums = create_files_with_md5sums(mount_point, 100)
+    with TestRun.step(
+        """Compare md5 susms between original files, files on IntelCAS device
+        and files copied from intelCAS device"""
+    ):
+        compare_md5sums(md5_sums, mount_point, copy_to_tmp=True)


### PR DESCRIPTION
Added test for multilevel cache creation in `test_multilevel_cache_3` and modified `compare_md5sums` function which was moved to `common.py` in the same directory
Signed-off-by: Damian Raczkowski <damian.raczkowski@intel.com>