### PR TITLE
Fix dracut warning

### DIFF
--- a/utils/etc/dracut.conf.d/opencas.conf
+++ b/utils/etc/dracut.conf.d/opencas.conf
@@ -1,1 +1,1 @@
-omit_drivers+=" cas_cache"
+omit_drivers+=" cas_cache "


### PR DESCRIPTION
Dracut requires values appended to config to be surrounded by whitespace

Signed-off-by: Jan Musial <jan.musial@intel.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-cas/open-cas-linux/1354)
<!-- Reviewable:end -->
