### PR TITLE
Fix license headers in tests

### DIFF
--- a/test/functional/tests/io_class/test_io_class_preserve_config.py
+++ b/test/functional/tests/io_class/test_io_class_preserve_config.py
@@ -1,6 +1,6 @@
 #
 # Copyright(c) 2022 Intel Corporation
-# SPDX-License-Identifier: BSD-3-Clause-Clear
+# SPDX-License-Identifier: BSD-3-Clause
 #
 
 import pytest

--- a/test/functional/tests/io_class/test_io_class_service_support.py
+++ b/test/functional/tests/io_class/test_io_class_service_support.py
@@ -1,6 +1,6 @@
 #
 # Copyright(c) 2022 Intel Corporation
-# SPDX-License-Identifier: BSD-3-Clause-Clear
+# SPDX-License-Identifier: BSD-3-Clause
 #
 
 import os

--- a/test/functional/tests/lazy_writes/cleaning_policy/test_cleaning_params.py
+++ b/test/functional/tests/lazy_writes/cleaning_policy/test_cleaning_params.py
@@ -1,6 +1,6 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
-# SPDX-License-Identifier: BSD-3-Clause-Clear
+# Copyright(c) 2019-2022 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
 #
 
 import time

--- a/test/functional/tests/stress/test_stress_change_io_class_config_io.py
+++ b/test/functional/tests/stress/test_stress_change_io_class_config_io.py
@@ -1,6 +1,6 @@
 #
 # Copyright(c) 2022 Intel Corporation
-# SPDX-License-Identifier: BSD-3-Clause-Clear
+# SPDX-License-Identifier: BSD-3-Clause
 #
 
 import os


### PR DESCRIPTION
Some tests added after license cleanup still have bad license header. Change it to the proper one.

Signed-off-by: Robert Baldyga <robert.baldyga@intel.com>