### PR TITLE
tests: do not run test_core_device_error in lazy write cache modes

### DIFF
--- a/test/functional/api/cas/cache_config.py
+++ b/test/functional/api/cas/cache_config.py
@@ -61,6 +61,12 @@ class CacheMode(Enum):
         ]
 
     @staticmethod
+    def without_traits(flags: CacheModeTrait):
+        return [
+            m for m in CacheMode if not any(map(lambda t: t in CacheMode.get_traits(m), flags))
+        ]
+
+    @staticmethod
     def with_any_trait(flags: CacheModeTrait):
         return [
             m for m in CacheMode if any(map(lambda t: t in CacheMode.get_traits(m), flags))

--- a/test/functional/tests/fault_injection/test_primary_device_error.py
+++ b/test/functional/tests/fault_injection/test_primary_device_error.py
@@ -12,6 +12,7 @@ from core.test_run import TestRun
 from api.cas import casadm
 from api.cas.cache_config import (
     CacheMode,
+    CacheModeTrait,
     CacheLineSize,
     SeqCutOffPolicy,
     CleaningPolicy,
@@ -22,7 +23,7 @@ from test_utils.size import Size, Unit
 
 
 @pytest.mark.parametrizex("cache_line_size", CacheLineSize)
-@pytest.mark.parametrizex("cache_mode", CacheMode)
+@pytest.mark.parametrizex("cache_mode", CacheMode.without_traits(CacheModeTrait.LazyWrites))
 @pytest.mark.parametrizex("io_dir", [ReadWrite.randread, ReadWrite.randwrite])
 @pytest.mark.require_disk("cache", DiskTypeSet([DiskType.optane, DiskType.nand]))
 @pytest.mark.require_disk("core", DiskTypeLowerThan("cache"))


### PR DESCRIPTION
This test has multiple assumptions that do not hold for WB/WO:

1. it assumes primary storage errors would propagate to user I/O
2. cache is stopped with metadata flush, which would fail
3. after stopping CAS core content is verified with fio
4. cache is so small that it overfills, resulting in PT I/O further
complicating error accounting.