### PR TITLE
Fix for incorrect header file handling in ./configure

### DIFF
--- a/configure.d/1_bdev_nr_sectors.conf
+++ b/configure.d/1_bdev_nr_sectors.conf
@@ -13,7 +13,7 @@ check() {
     if compile_module $cur_name "bdev_nr_sectors(NULL);" "linux/genhd.h"
     then
         echo $cur_name 1 >> $config_file_path
-    elif compile_module $cur_name "struct block_device *bd; bd->bd_part->nr_sects;" "linux/blk_types.h"
+    elif compile_module $cur_name "struct block_device *bd; bd->bd_part->nr_sects;" "linux/blk_types.h" "linux/genhd.h"
     then
         echo $cur_name 2 >> $config_file_path
     else

--- a/configure.d/1_bdev_whole.conf
+++ b/configure.d/1_bdev_whole.conf
@@ -13,7 +13,7 @@ check() {
     if compile_module $cur_name "struct block_device *bd; bdev_whole(bd);" "linux/blk_types.h" "linux/genhd.h"
     then
         echo $cur_name 1 >> $config_file_path
-    elif compile_module $cur_name "struct block_device *bd; bd->bd_contains;" "linux/blk_types.h"
+    elif compile_module $cur_name "struct block_device *bd; bd->bd_contains;" "linux/blk_types.h" "linux/fs.h"
     then
         echo $cur_name 2 >> $config_file_path
     else

--- a/configure.d/conf_framework.sh
+++ b/configure.d/conf_framework.sh
@@ -21,6 +21,7 @@ add_function() {
 }
 
 __compile_module(){
+	INCLUDE=""
 	if [ $# -gt 1 ]
 	then
 		i=2


### PR DESCRIPTION
In specific cases, header files will be included incorrectly during the configuration phase, leading to erroneous failure of affected configure step.

This patch fixes this issue.

Signed-off-by: Krzysztof Majzerowicz-Jaszcz <krzysztof.majzerowicz-jaszcz@intel.com>