### PR TITLE
Merge flush and cache commands

### DIFF
--- a/casadm/cas_main.c
+++ b/casadm/cas_main.c
@@ -1262,25 +1262,16 @@ int handle_reset_counters()
 			command_args_values.core_id);
 }
 
-static cli_option flush_core_options[] = {
+static cli_option flush_cache_options[] = { 
 	{'i', "cache-id", CACHE_ID_DESC, 1, "ID", CLI_OPTION_REQUIRED},
-	{'j', "core-id", CORE_ID_DESC, 1, "ID", CLI_OPTION_REQUIRED},
-	{0}
-};
-
-int handle_flush_core()
-{
-	return flush_core(command_args_values.cache_id,
-			command_args_values.core_id);
-}
-
-static cli_option flush_cache_options[] = {
-	{'i', "cache-id", CACHE_ID_DESC, 1, "ID", CLI_OPTION_REQUIRED},
+	{'j', "core-id", CORE_ID_DESC, 1, "ID", CLI_OPTION_OPTIONAL_ARG},
 	{0}
 };
 
 int handle_flush_cache()
 {
+	if(command_args_values.core_id != OCF_CORE_ID_INVALID)
+		return flush_core(command_args_values.cache_id, command_args_values.core_id);
 	return flush_cache(command_args_values.cache_id);
 }
 
@@ -2339,17 +2330,6 @@ static cli_command cas_commands[] = {
 			.options = flush_cache_options,
 			.command_handle_opts = command_handle_option,
 			.handle = handle_flush_cache,
-			.flags = CLI_SU_REQUIRED,
-			.help = NULL,
-		},
-		{
-			.name = "flush-core",
-			.short_name = 'E',
-			.desc = "Flush dirty data of a given core from the caching device to this core device",
-			.long_desc = NULL,
-			.options = flush_core_options,
-			.command_handle_opts = command_handle_option,
-			.handle = handle_flush_core,
 			.flags = CLI_SU_REQUIRED,
 			.help = NULL,
 		},

--- a/casadm/casadm.8
+++ b/casadm/casadm.8
@@ -48,7 +48,7 @@ cleaning. Cleaning may be required if cache is full and eviction (replacement)
 policy needs to remove stale data to make space for incoming blocks. Open CAS
 provides mechanism which automatically cleans dirty data in background. This is
 cleaning (flushing) thread. User can also invoke manual cleaning procedure (see
--E, --flush-cache and -F --flush-core options). Write-Back cache, also known as
+--flush-cache, -F  options). Write-Back cache, also known as
 Write Cache, improves performance of both read and write IO operations.
 
 .TP
@@ -123,9 +123,6 @@ Reset statistics of given cache/core instance.
 .B -F, --flush-cache
 Flush all dirty data from the caching device to core devices.
 
-.TP
-.B -E, --flush-core
-Flush dirty data of a given core from the caching device to this core device.
 
 .TP
 .B -C, --io-class {--load-config|--list}
@@ -554,14 +551,11 @@ is not specified, statistics are reset for all cores within given cache instance
 .B -i, --cache-id <ID>
 Identifier of cache instance <1-16384>.
 
-.SH Options that are valid with --flush-core (-E) are:
-.TP
-.B -i, --cache-id <ID>
-Identifier of cache instance <1-16384>.
-
 .TP
 .B -j, --core-id <ID>
-Identifier of core instance <0-4095> within given cache instance.
+Identifier of core instance <0-4095> within given cache instance. This is an
+optional parameter When provided, it will flush core with provided id
+connected to cache. In other case it will flush cache.   
 
 .SH Options that are valid with --io-class --load-config (-C -C) are:
 .TP

--- a/test/functional/api/cas/cli.py
+++ b/test/functional/api/cas/cli.py
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2019-2021 Intel Corporation
+# Copyright(c) 2019-2022 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
@@ -85,8 +85,8 @@ def flush_cache_cmd(cache_id: str, shortcut: bool = False):
 
 
 def flush_core_cmd(cache_id: str, core_id: str, shortcut: bool = False):
-    command = (f" -E -i {cache_id} -j {core_id}" if shortcut
-               else f" --flush-core --cache-id {cache_id} --core-id {core_id}")
+    command = (f" -F -i {cache_id} -j {core_id}" if shortcut
+               else f" --flush-cache --cache-id {cache_id} --core-id {core_id}")
     return casadm_bin + command
 
 

--- a/test/functional/api/cas/cli_help_messages.py
+++ b/test/functional/api/cas/cli_help_messages.py
@@ -20,8 +20,6 @@ casadm_help = [
     r"-P  --stats                    Print statistics for cache instance",
     r"-Z  --reset-counters           Reset cache statistics for core device within cache instance",
     r"-F  --flush-cache              Flush all dirty data from the caching device to core devices",
-    r"-E  --flush-core               Flush dirty data of a given core from the caching device "
-    r"to this core device",
     r"-C  --io-class                 Manage IO classes",
     r"-V  --version                  Print CAS version",
     r"-H  --help                     Print help",
@@ -61,20 +59,14 @@ ioclass_help = [
     r"-o  --output-format \<FORMAT\>        Output format: \{table|csv\}"
 ]
 
-flush_core_help = [
-    r"Usage: casadm --flush-core --cache-id \<ID\> --core-id \<ID\>",
-    r"Flush dirty data of a given core from the caching device to this core device",
-    r"Options that are valid with --flush-core \(-E\) are:",
-    r"-i  --cache-id \<ID\>                 Identifier of cache instance \<1-16384\>",
-    r"-j  --core-id \<ID\>                  Identifier of core \<0-4095\> within given cache "
-    r"instance"
-]
-
 flush_cache_help = [
     r"Usage: casadm --flush-cache --cache-id \<ID\>",
     r"Flush all dirty data from the caching device to core devices",
     r"Options that are valid with --flush-cache \(-F\) are:",
     r"-i  --cache-id \<ID\>                 Identifier of cache instance \<1-16384\>"
+    r"-j  --core-id \<ID\>                  Identifier of core \<0-4095\> within given cache "
+    r"instance. This is an optional parameter When provided, it will flush core with provided"
+    r" id connected to cache. In other case it will flush cache."
 ]
 
 reset_counters_help = [

--- a/test/functional/tests/cli/test_cli_help_and_version.py
+++ b/test/functional/tests/cli/test_cli_help_and_version.py
@@ -74,10 +74,6 @@ def test_cli_help(shortcut):
                                   + (" -H" if shortcut else " --help"))
     check_stdout_msg(output, flush_cache_help)
 
-    output = TestRun.executor.run("casadm" + (" -E" if shortcut else " --flush-core")
-                                  + (" -H" if shortcut else " --help"))
-    check_stdout_msg(output, flush_core_help)
-
     output = TestRun.executor.run("casadm" + (" -C" if shortcut else " --io-class")
                                   + (" -H" if shortcut else " --help"))
     check_stdout_msg(output, ioclass_help)

--- a/test/smoke_test/cas_functions
+++ b/test/smoke_test/cas_functions
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2012-2022 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
@@ -530,7 +530,7 @@ flush_cache() {
 flush_core() {
     check_options ${FUNCNAME[0]}
 
-    local COMMAND="$CAS --flush-core --cache-id $CACHE_ID_OPTION --core-id $CORE_ID_OPTION"
+    local COMMAND="$CAS --flush-cache --cache-id $CACHE_ID_OPTION --core-id $CORE_ID_OPTION"
 
     run_cmd $COMMAND
     clear_options


### PR DESCRIPTION
Merged `casadm -E casadm -F` commands into one: `casadm -F`. It will be accepting two params: 
- `-i <id>` or `--cache-id <id>` id of cache which is going to be flushed.  It is a **required** parameter.
- `-j <id>` or `--core-id <id>` id of core which is going to be flushed  It is an **optional** parameter.
If you provide both `cache-id ` and `core-id` parameters, flush will be performed from the specified cache device to the specified associated core device.  In case of providing `cache-id ` param only, flush will be performed from the specified cache device to all the associated core devices.

Signed-off-by: Damian Raczkowski [damian.raczkowski@intel.com](mailto:damian.raczkowski@intel.com)