### PR TITLE
Improve --set-param error message 

### DIFF
--- a/casadm/cas_lib.c
+++ b/casadm/cas_lib.c
@@ -1085,6 +1085,8 @@ int get_cache_mode(int ctrl_fd, unsigned int cache_id, int *mode)
 
 	if (ioctl(ctrl_fd, KCAS_IOCTL_CACHE_INFO, &cmd_info) < 0)
 	{
+		if (cmd_info.ext_err_code == OCF_ERR_CACHE_NOT_EXIST)
+			print_err(cmd_info.ext_err_code);
 		if (cmd_info.ext_err_code == OCF_ERR_CACHE_STANDBY)
 			print_err(cmd_info.ext_err_code);
 		return FAILURE;


### PR DESCRIPTION
Add print error message when invoked `--set-param` command  with `--cache-id` that does not exist pointing user that this is the issue. It resolves #1390

Now after invoking --set-param with id to the cache that does not exists, it will print given message: 
![image](https://user-images.githubusercontent.com/57325417/201065134-344f18d1-2872-4038-b131-5527bbf0173f.png)

Signed-off-by: Damian Raczkowski <damian.raczkowski@intel.com>