### PR TITLE
Version comparison logic fix for RHEL workaround.

### DIFF
--- a/configure.d/1_blk_queue_exit_workaround_for_rhel.conf
+++ b/configure.d/1_blk_queue_exit_workaround_for_rhel.conf
@@ -46,10 +46,10 @@ compare_version () {
 }
 
 compare_kernel_version () {
-    compare_version $1 $2 $3 $LINUX_MAJOR $LINUX_MINOR $LINUX_SUB $4
+    compare_version $LINUX_MAJOR $LINUX_MINOR $LINUX_SUB $1 $2 $3 $4
 }
 compare_rhel_kernel_version () {
-    compare_version $1 $2 $3 $RHEL_MAJOR $RHEL_MINOR $RHEL_SUB $4
+    compare_version $RHEL_MAJOR $RHEL_MINOR $RHEL_SUB $1 $2 $3 $4
 }
 
 check () {


### PR DESCRIPTION
This patch fixes the RHEL 8.7 hung task problem by correcting the version comparison logic in the RHEL workaround configure step.

Signed-off-by: Krzysztof Majzerowicz-Jaszcz <krzysztof.majzerowicz-jaszcz@intel.com>