### PR TITLE
Change CAS_BIO_MAX_VECS value

### DIFF
--- a/configure.d/1_bio_max_vecs.conf
+++ b/configure.d/1_bio_max_vecs.conf
@@ -20,9 +20,9 @@ check() {
 apply() {
     case "$1" in
     "1")
-	;;
+        add_define "CAS_BIO_MAX_VECS ((uint32_t)BIO_MAX_VECS)" ;;
     "2")
-        add_define "BIO_MAX_VECS ((uint32_t)(-1))" ;;
+        add_define "CAS_BIO_MAX_VECS ((uint32_t)BIO_MAX_PAGES)" ;;
     *)
         exit 1
     esac

--- a/modules/cas_cache/volume/vol_blk_utils.h
+++ b/modules/cas_cache/volume/vol_blk_utils.h
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2012-2021 Intel Corporation
+* Copyright(c) 2012-2022 Intel Corporation
 * SPDX-License-Identifier: BSD-3-Clause
 */
 
@@ -90,7 +90,7 @@ static inline uint32_t cas_io_iter_size_done(struct bio_vec_iter *iter)
 static inline uint32_t cas_io_iter_size_left(struct bio_vec_iter *iter)
 {
 	if (iter->idx < iter->vec_size)
-		return min(iter->vec_size - iter->idx, BIO_MAX_VECS);
+		return min(iter->vec_size - iter->idx, CAS_BIO_MAX_VECS);
 	return 0;
 	/* TODO UNITTEST */
 }


### PR DESCRIPTION
Previously when user tried to allocate to big bio he recieved NULL. As the behavior was changed to `BUG()` passing out of range value is no longer legal.

Limiting the requested bio size to BIO_MAX_PAGES (on the older kernels) or to BIO_MAX_VECS (on the newer ones) eliminates the problem as the macros represent the max possible value.

Signed-off-by: Michal Mielewczyk <michal.mielewczyk@intel.com>