### PR TITLE
Set gd->queue to NULL after queue cleanup

### DIFF
--- a/configure.d/2_alloc_disk.conf
+++ b/configure.d/2_alloc_disk.conf
@@ -34,9 +34,9 @@ apply() {
 		return 0;
         }"
 	add_function "
-	static inline void cas_cleanup_mq_disk(struct cas_exp_obj *exp_obj)
+	static inline void cas_cleanup_mq_disk(struct gendisk *gd)
 	{
-		cas_cleanup_disk(exp_obj->gd);
+		cas_cleanup_disk(gd);
 	}"
 	;;
 
@@ -61,9 +61,11 @@ apply() {
         }"
 
 	add_function "
-	static inline void cas_cleanup_mq_disk(struct cas_exp_obj *exp_obj){
-		blk_cleanup_queue(exp_obj->queue);
-		put_disk(exp_obj->gd);
+	static inline void cas_cleanup_mq_disk(struct gendisk *gd)
+	{
+		blk_cleanup_queue(gd->queue);
+		gd->queue = NULL;
+		put_disk(gd);
 	}"
 	;;
 

--- a/modules/cas_cache/exp_obj.c
+++ b/modules/cas_cache/exp_obj.c
@@ -502,8 +502,8 @@ error_set_geometry:
 	exp_obj->private = NULL;
 	_cas_exp_obj_clear_dev_t(dsk);
 error_exp_obj_set_dev_t:
-	cas_cleanup_mq_disk(exp_obj);
-	dsk->exp_obj->gd = NULL;
+	cas_cleanup_mq_disk(gd);
+	exp_obj->gd = NULL;
 error_alloc_mq_disk:
 	blk_mq_free_tag_set(&exp_obj->tag_set);
 error_init_tag_set:


### PR DESCRIPTION
Otherwise put_disk() tries to access the queue which leads to kernel panic.

Signed-off-by: Robert Baldyga <robert.baldyga@intel.com>