### PR TITLE
[v22.6.2] Set gd->queue to NULL after queue cleanup

### DIFF
--- a/configure.d/1_alloc_disk.conf
+++ b/configure.d/1_alloc_disk.conf
@@ -34,9 +34,9 @@ apply() {
 		return 0;
         }"
 	add_function "
-	static inline void cas_cleanup_mq_disk(struct casdsk_exp_obj *exp_obj)
+	static inline void cas_cleanup_mq_disk(struct gendisk *gd)
 	{
-		blk_cleanup_disk(exp_obj->gd);
+		blk_cleanup_disk(gd);
 	}"
 	;;
 
@@ -61,9 +61,11 @@ apply() {
         }"
 
 	add_function "
-	static inline void cas_cleanup_mq_disk(struct casdsk_exp_obj *exp_obj){
-		blk_cleanup_queue(exp_obj->queue);
-		put_disk(exp_obj->gd);
+	static inline void cas_cleanup_mq_disk(struct gendisk *gd)
+    {
+		blk_cleanup_queue(gd->queue);
+		gd->queue = NULL;
+		put_disk(gd);
 	}"
 	;;
 

--- a/modules/cas_disk/exp_obj.c
+++ b/modules/cas_disk/exp_obj.c
@@ -602,8 +602,8 @@ int casdsk_exp_obj_create(struct casdsk_disk *dsk, const char *dev_name,
 error_set_geometry:
 	_casdsk_exp_obj_clear_dev_t(dsk);
 error_exp_obj_set_dev_t:
-	cas_cleanup_mq_disk(exp_obj);
-	dsk->exp_obj->gd = NULL;
+	cas_cleanup_mq_disk(gd);
+	exp_obj->gd = NULL;
 error_alloc_mq_disk:
 	blk_mq_free_tag_set(&dsk->tag_set);
 error_init_tag_set:


### PR DESCRIPTION
Otherwise put_disk() tries to access the queue which leads to kernel panic.

Signed-off-by: Robert Baldyga <robert.baldyga@intel.com>