### PR TITLE
[v22.6.2] Set dsk->exp_obj to NULL to avoid double kobject_put()

### DIFF
--- a/modules/cas_disk/exp_obj.c
+++ b/modules/cas_disk/exp_obj.c
@@ -608,6 +608,7 @@ error_alloc_mq_disk:
 	blk_mq_free_tag_set(&dsk->tag_set);
 error_init_tag_set:
 	kobject_put(&exp_obj->kobj);
+	dsk->exp_obj = NULL;
 	/* kobject put does all the cleanup below internally */
 	return result;
 error_init_kobject:


### PR DESCRIPTION
Otherwise casdsk_disk_close() will attempt casdsk_exp_obj_free(), which calls kobject_put() once again when dsk->exp_obj is not NULL.

It leads to following warning:
refcount_t: underflow; use-after-free.
WARNING: CPU: 48 PID: 56865 at lib/refcount.c:28 refcount_warn_saturate+0xf4/0x15

Signed-off-by: Robert Baldyga <robert.baldyga@intel.com>