### PR TITLE
test-framework: Changing the template html < and > to lt/gt entities

### DIFF
--- a/test/functional/test-framework/log/template/iterations/iteration.html
+++ b/test/functional/test-framework/log/template/iterations/iteration.html
@@ -18,11 +18,11 @@
                 <option style="background-color: white; color: black" value="debug">Debug</option>
             </select>
             <b>Errors: </b>
-            <button onclick="previousError()"><</button>
+            <button onclick="previousError()">&lt;</button>
             <select id="error-list-selector" onchange="errorSelected('error-list-selector')">
                 <option value="top" class="empty">-empty-</option>
             </select>
-            <button onclick="nextError()">></button>
+            <button onclick="nextError()">&gt;</button>
         </div>
         <br/>
         <a name="top"><h1 class="iteration-title" style="border-bottom: 4px solid rgba(255, 0, 0, 1)">[title]</h1></a>

--- a/test/functional/test-framework/log/template/iterations/setup.html
+++ b/test/functional/test-framework/log/template/iterations/setup.html
@@ -18,11 +18,11 @@
                 <option style="background-color: white; color: black" value="debug">Debug</option>
             </select>
             <b>Errors: </b>
-            <button onclick="previousError()"><</button>
+            <button onclick="previousError()">&lt;</button>
             <select id="error-list-selector" onchange="errorSelected('error-list-selector')">
                 <option value="top">-empty-</option>
             </select>
-            <button onclick="nextError()">></button>
+            <button onclick="nextError()">&gt;</button>
         </div>
         <br/>
         <a name="top">


### PR DESCRIPTION
Some xpath parsers get confused by the explicit < and > characters.