### PR TITLE
Fix compile on Rockylinux 9

### DIFF
--- a/modules/cas_cache/exp_obj.c
+++ b/modules/cas_cache/exp_obj.c
@@ -31,18 +31,25 @@ static inline void bd_release_from_disk(struct block_device *bdev,
 	return bd_unlink_disk_holder(bdev, disk);
 }
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 18, 0)
-	#define KRETURN(x) 	return
-	#define MAKE_RQ_RET_TYPE void
-#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 3, 0)
-	#define KRETURN(x)	({ return (x); })
-	#define MAKE_RQ_RET_TYPE blk_qc_t
-#elif LINUX_VERSION_CODE >= KERNEL_VERSION(3, 2, 0)
-	#define KRETURN(x)	return
-	#define MAKE_RQ_RET_TYPE void
+#ifdef RHEL_MAJOR
+       #if RHEL_MAJOR >= 9
+               #define KRETURN(x)      return
+               #define MAKE_RQ_RET_TYPE void
+       #endif
 #else
-	#define KRETURN(x)	({ return (x); })
-	#define MAKE_RQ_RET_TYPE int
+       #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 18, 0)
+               #define KRETURN(x)      return
+               #define MAKE_RQ_RET_TYPE void
+       #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 3, 0)
+               #define KRETURN(x)      ({ return (x); })
+               #define MAKE_RQ_RET_TYPE blk_qc_t
+       #elif LINUX_VERSION_CODE >= KERNEL_VERSION(3, 2, 0)
+               #define KRETURN(x)      return
+               #define MAKE_RQ_RET_TYPE void
+       #else
+               #define KRETURN(x)      ({ return (x); })
+               #define MAKE_RQ_RET_TYPE int
+       #endif
 #endif
 
 int __init cas_init_exp_objs(void)


### PR DESCRIPTION
Due to custom patches on the RHEL kernel, MAKE_RQ_RET_TYPE uses kernel 5.18.0 and above struct type. this fix prevents using blk_qc_t on Rockylinux 9.