### PR TITLE
Handle missing /etc/mtab and modify output

### DIFF
--- a/casadm/cas_lib.c
+++ b/casadm/cas_lib.c
@@ -45,8 +45,8 @@
 
 #define CORE_ADD_MAX_TIMEOUT 30
 
-int is_cache_mounted(int cache_id);
-int is_core_mounted(int cache_id, int core_id);
+bool cache_mounts_detected(int cache_id);
+bool core_mounts_detected(int cache_id, int core_id);
 
 /* KCAS_IOCTL_CACHE_CHECK_DEVICE  wrapper */
 int _check_cache_device(const char *device_path,
@@ -1119,7 +1119,7 @@ int stop_cache(uint16_t cache_id, int flush)
 	int status;
 
 	/* Don't stop instance with mounted filesystem */
-	if (is_cache_mounted(cache_id) == FAILURE)
+	if (cache_mounts_detected(cache_id))
 		return FAILURE;
 
 	fd = open_ctrl_device();
@@ -1803,58 +1803,60 @@ int add_core(unsigned int cache_id, unsigned int core_id, const char *core_devic
 	return SUCCESS;
 }
 
-int _check_if_mounted(int cache_id, int core_id)
+bool _device_mounts_detected(int cache_id, int core_id)
 {
 	FILE *mtab;
 	struct mntent *mstruct;
 	char dev_buf[80];
-	int difference = 0, error = 0;
+	int no_match = 0, error = 0, cmplen = 0;
 	if (core_id >= 0) {
 		/* verify if specific core is mounted */
-		snprintf(dev_buf, sizeof(dev_buf), "/dev/cas%d-%d", cache_id, core_id);
+		cmplen = snprintf(dev_buf, sizeof(dev_buf), "/dev/cas%d-%d", cache_id, core_id);
 	} else {
-		/* verify if any core from given cache is mounted */
-		snprintf(dev_buf, sizeof(dev_buf), "/dev/cas%d-", cache_id);
+		/* verify if any core from given cache is mounted
+		   do not compare terminating NULL for cache */
+		cmplen = snprintf(dev_buf, sizeof(dev_buf), "/dev/cas%d-", cache_id) - 1;
 	}
 
 	mtab = setmntent("/etc/mtab", "r");
-	if (!mtab)
-	{
-		cas_printf(LOG_ERR, "Error while accessing /etc/mtab\n");
-		return FAILURE;
+	if (!mtab) {
+		/* if /etc/mtab not found then the kernel will check for mounts */
+		return false;
 	}
 
 	while ((mstruct = getmntent(mtab)) != NULL) {
-		error = strcmp_s(mstruct->mnt_fsname, PATH_MAX, dev_buf, &difference);
+		error = strcmp_s(mstruct->mnt_fsname, cmplen, dev_buf, &no_match);
 		/* mstruct->mnt_fsname is /dev/... block device path, not a mountpoint */
 		if (error != EOK)
-			return FAILURE;
-		if (!difference) {
-			if (core_id<0) {
-				cas_printf(LOG_ERR,
-					   "Can't stop cache instance %d. Device %s is mounted!\n",
-					   cache_id, mstruct->mnt_fsname);
-			} else {
-				cas_printf(LOG_ERR,
-					   "Can't remove core %d from cache %d."
-					   " Device %s is mounted!\n",
-					   core_id, cache_id, mstruct->mnt_fsname);
-			}
-			return FAILURE;
+			return false;
+		if (no_match)
+			continue;
+
+		if (core_id < 0) {
+			cas_printf(LOG_ERR,
+				   "Can't stop cache instance %d. Device %s is mounted!\n",
+				   cache_id, mstruct->mnt_fsname);
+		} else {
+			cas_printf(LOG_ERR,
+				   "Can't remove core %d from cache %d."
+				   " Device %s is mounted!\n",
+				   core_id, cache_id, mstruct->mnt_fsname);
 		}
+
+		return true;
 	}
-	return SUCCESS;
 
+	return false;
 }
 
-int is_cache_mounted(int cache_id)
+bool cache_mounts_detected(int cache_id)
 {
-	return _check_if_mounted(cache_id, -1);
+	return _device_mounts_detected(cache_id, -1);
 }
 
-int is_core_mounted(int cache_id, int core_id)
+bool core_mounts_detected(int cache_id, int core_id)
 {
-	return _check_if_mounted(cache_id, core_id);
+	return _device_mounts_detected(cache_id, core_id);
 }
 
 int remove_core(unsigned int cache_id, unsigned int core_id,
@@ -1864,7 +1866,7 @@ int remove_core(unsigned int cache_id, unsigned int core_id,
 	struct kcas_remove_core cmd;
 
 	/* don't even attempt ioctl if filesystem is mounted */
-	if (SUCCESS != is_core_mounted(cache_id, core_id)) {
+	if (core_mounts_detected(cache_id, core_id)) {
 		return FAILURE;
 	}
 
@@ -1928,11 +1930,6 @@ int remove_inactive_core(unsigned int cache_id, unsigned int core_id,
 {
 	int fd = 0;
 	struct kcas_remove_inactive cmd;
-
-	/* don't even attempt ioctl if filesystem is mounted */
-	if (SUCCESS != is_core_mounted(cache_id, core_id)) {
-		return FAILURE;
-	}
 
 	fd = open_ctrl_device();
 	if (fd == -1)

--- a/test/functional/api/cas/cli_messages.py
+++ b/test/functional/api/cas/cli_messages.py
@@ -84,7 +84,7 @@ already_cached_core = [
 ]
 
 remove_mounted_core = [
-    r"Can\'t remove core \d+ from cache \d+\. Device /dev/cas\d+-\d+(p\d+|) is mounted\!"
+    r"Can\'t remove core \d+ from cache \d+ due to mounted devices:"
 ]
 
 remove_mounted_core_kernel = [
@@ -93,7 +93,7 @@ remove_mounted_core_kernel = [
 ]
 
 stop_cache_mounted_core = [
-    r"Can\'t stop cache instance \d+\. Device /dev/cas\d+-\d+(p\d+|) is mounted\!"
+    r"Can\'t stop cache instance \d+ due to mounted devices:"
 ]
 
 stop_cache_mounted_core_kernel = [

--- a/test/functional/api/cas/cli_messages.py
+++ b/test/functional/api/cas/cli_messages.py
@@ -1,6 +1,6 @@
 #
 # Copyright(c) 2019-2022 Intel Corporation
-# Copyright(c) 2024 Huawei Technologies Co., Ltd.
+# Copyright(c) 2024 Huawei Technologies
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
@@ -84,11 +84,20 @@ already_cached_core = [
 ]
 
 remove_mounted_core = [
-    r"Can\'t remove core \d+ from cache \d+\. Device /dev/cas\d+-\d+ is mounted\!"
+    r"Can\'t remove core \d+ from cache \d+\. Device /dev/cas\d+-\d+(p\d+|) is mounted\!"
+]
+
+remove_mounted_core_kernel = [
+    r"Error while removing core device \d+ from cache instance \d+",
+    r"Device opens or mount are pending to this cache",
 ]
 
 stop_cache_mounted_core = [
-    r"Error while removing cache \d+",
+    r"Can\'t stop cache instance \d+\. Device /dev/cas\d+-\d+(p\d+|) is mounted\!"
+]
+
+stop_cache_mounted_core_kernel = [
+    r"Error while stopping cache \d+",
     r"Device opens or mount are pending to this cache",
 ]
 
@@ -242,7 +251,7 @@ def __check_string_msg(text: str, expected_messages, negate=False):
             msg_ok = False
         elif matches and negate:
             TestRun.LOGGER.error(
-                f"Message is incorrect, expected to not find: {msg}\n " f"actual: {text}."
+                f"Message is incorrect, expected to not find: {msg}\n actual: {text}."
             )
             msg_ok = False
     return msg_ok

--- a/test/functional/tests/fault_injection/test_fault_injection_with_mounted_core.py
+++ b/test/functional/tests/fault_injection/test_fault_injection_with_mounted_core.py
@@ -1,5 +1,6 @@
 #
 # Copyright(c) 2019-2022 Intel Corporation
+# Copyright(c) 2024 Huawei Technologies
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
@@ -10,11 +11,12 @@ from core.test_run import TestRun
 from storage_devices.disk import DiskType, DiskTypeSet, DiskTypeLowerThan
 from test_tools import fs_utils
 from test_tools.disk_utils import Filesystem
+from test_utils.filesystem.file import File
+from test_utils.filesystem.symlink import Symlink
 from test_utils.size import Size, Unit
 
 mount_point = "/mnt/cas"
 test_file_path = f"{mount_point}/test_file"
-
 
 
 @pytest.mark.require_disk("cache", DiskTypeSet([DiskType.optane, DiskType.nand]))
@@ -89,6 +91,7 @@ def test_stop_cache_with_mounted_partition():
           - No system crash.
           - Unable to stop cache when partition is mounted.
           - Unable to remove core when partition is mounted.
+          - casadm displays proper message.
     """
     with TestRun.step("Prepare cache and core devices. Start CAS."):
         cache_dev = TestRun.disks['cache']
@@ -103,6 +106,10 @@ def test_stop_cache_with_mounted_partition():
         core_part.create_filesystem(Filesystem.xfs)
         core = cache.add_core(core_part)
         core.mount(mount_point)
+
+    with TestRun.step("Ensure /etc/mtab exists."):
+        if not fs_utils.check_if_file_exists("/etc/mtab"):
+            Symlink.create_symlink("/proc/self/mounts", "/etc/mtab")
 
     with TestRun.step("Try to remove core from cache."):
         output = TestRun.executor.run_expect_fail(cli.remove_core_cmd(cache_id=str(cache.cache_id),
@@ -119,3 +126,61 @@ def test_stop_cache_with_mounted_partition():
     with TestRun.step("Stop cache."):
         casadm.stop_all_caches()
 
+
+@pytest.mark.require_disk("cache", DiskTypeSet([DiskType.optane, DiskType.nand]))
+@pytest.mark.require_disk("core", DiskTypeLowerThan("cache"))
+def test_stop_cache_with_mounted_partition_no_mtab():
+    """
+        title: Test for removing core and stopping cache when casadm is unable to check mounts.
+        description: |
+          Negative test of the ability of CAS to remove core and stop cache while core
+          is still mounted and casadm is unable to check mounts.
+        pass_criteria:
+          - No system crash.
+          - Unable to stop cache when partition is mounted.
+          - Unable to remove core when partition is mounted.
+          - casadm displays proper message informing that mount check was performed by kernel module
+    """
+    with TestRun.step("Prepare cache and core devices. Start CAS."):
+        cache_dev = TestRun.disks['cache']
+        cache_dev.create_partitions([Size(1, Unit.GibiByte)])
+        cache_part = cache_dev.partitions[0]
+        core_dev = TestRun.disks['core']
+        core_dev.create_partitions([Size(4, Unit.GibiByte)])
+        core_part = core_dev.partitions[0]
+        cache = casadm.start_cache([cache_part], force=True)
+
+    with TestRun.step("Add core device with xfs filesystem and mount it."):
+        core_part.create_filesystem(Filesystem.xfs)
+        core = cache.add_core(core_part)
+        core.mount(mount_point)
+
+    with TestRun.step("Move /etc/mtab"):
+        if fs_utils.check_if_file_exists("/etc/mtab"):
+            mtab = File("/etc/mtab")
+        else:
+            mtab = Symlink.create_symlink("/proc/self/mounts", "/etc/mtab")
+        mtab.move("/tmp")
+
+    with TestRun.step("Try to remove core from cache."):
+        output = TestRun.executor.run_expect_fail(cli.remove_core_cmd(cache_id=str(cache.cache_id),
+                                                                      core_id=str(core.core_id)))
+        cli_messages.check_stderr_msg(output, cli_messages.remove_mounted_core_kernel)
+
+    with TestRun.step("Try to stop CAS."):
+        output = TestRun.executor.run_expect_fail(cli.stop_cmd(cache_id=str(cache.cache_id)))
+        cli_messages.check_stderr_msg(output, cli_messages.stop_cache_mounted_core_kernel)
+
+    with TestRun.step("Unmount core device."):
+        core.unmount()
+
+    with TestRun.step("Remove core."):
+        core.remove_core()
+
+    with TestRun.step("Re-add core."):
+        cache.add_core(core_part)
+
+    with TestRun.step("Stop cache."):
+        cache.stop()
+
+    mtab.move("/etc")


### PR DESCRIPTION
resolves https://github.com/Open-CAS/open-cas-linux/issues/1515

Output after modifications:
```
# lsblk
...
vdc          disk
└─cas1-1     disk /tmp/mnt2
vdd          disk
└─cas1-2     disk
  ├─cas1-2p1 part
  ├─cas1-2p2 part /tmp/mnt1
  ├─cas1-2p3 part
  └─cas1-2p4 part /tmp/mnt3
# casadm -L
type    id   disk       status    write policy   device
cache   1    /dev/vdb   Running   wt             -
├core   1    /dev/vdc   Active    -              /dev/cas1-1
└core   2    /dev/vdd   Active    -              /dev/cas1-2
# casadm -T -i 1
Can't stop cache instance 1 due to mounted devices:
/dev/cas1-2p2
/dev/cas1-1
/dev/cas1-2p4
# casadm -R -i 1 -j 1
Can't remove core 1 from cache 1 due to mounted devices:
/dev/cas1-1
# casadm -R -i 1 -j 2
Can't remove core 2 from cache 1 due to mounted devices:
/dev/cas1-2p2
/dev/cas1-2p4
```