### PR TITLE
Fix for cas service after changing path type to string in fs_utils remove command

### DIFF
--- a/test/functional/api/cas/cas_service.py
+++ b/test/functional/api/cas/cas_service.py
@@ -44,5 +44,5 @@ def set_cas_service_timeout(timeout: timedelta = timedelta(minutes=30)):
 
 
 def clear_cas_service_timeout():
-    remove(opencas_drop_in_directory, force=True, recursive=True, ignore_errors=True)
+    remove(str(opencas_drop_in_directory), force=True, recursive=True, ignore_errors=True)
     reload_daemon()

--- a/test/functional/tests/conftest.py
+++ b/test/functional/tests/conftest.py
@@ -243,7 +243,7 @@ def base_prepare(item):
             except Exception:
                 pass  # TODO: Reboot DUT if test is executed remotely
 
-        remove(opencas_drop_in_directory, recursive=True, ignore_errors=True)
+        remove(str(opencas_drop_in_directory), recursive=True, ignore_errors=True)
 
         from storage_devices.drbd import Drbd
         if Drbd.is_installed():


### PR DESCRIPTION
Needs: https://github.com/Open-CAS/test-framework/pull/14