### PR TITLE
Restore the explanation for NOMERGES flag

### DIFF
--- a/configure.d/1_queue_limits.conf
+++ b/configure.d/1_queue_limits.conf
@@ -49,6 +49,14 @@ apply() {
 		exp_q->limits.max_write_same_sectors = 0;
 	}"
 
+	 # A workaround for RHEL/CentOS 7.3 bug in kernel.
+	 # Merging implementation on blk-mq does not respect virt boundary
+	 # restriction and front merges bios with non-zero offsets.
+	 # This leads to request with gaps between bios and in consequence
+	 # triggers BUG_ON() in nvme driver or silently corrupts data.
+	 # To prevent this, disable merging on cache queue if there are
+	 # requirements regarding virt boundary (marking bios with REQ_NOMERGE
+	 # does not solve this problem).
 		add_function "
 	static inline void cas_cache_set_no_merges_flag(struct request_queue *cache_q)
 	{


### PR DESCRIPTION
The comment was remved in 1e5355eba1fe81154088622ed1274dc2ac13cb