### PR TITLE
tests: fix test_flush_over_640_gibibytes_with_fs

### DIFF
--- a/test/functional/tests/lazy_writes/test_flush_huge_dirty_data.py
+++ b/test/functional/tests/lazy_writes/test_flush_huge_dirty_data.py
@@ -83,10 +83,10 @@ def test_flush_over_640_gibibytes_with_fs(cache_mode, fs):
         fio.run()
         test_file_main.refresh_item()
 
-    with TestRun.step("Validate test file and read its md5 sum."):
+    with TestRun.step("Validate test file and read its crc32 sum."):
         if test_file_main.size != file_size:
             TestRun.fail("Created test file hasn't reached its target size.")
-        test_file_md5sum_main = test_file_main.md5sum()
+        test_file_crc32sum_main = test_file_main.crc32sum()
 
     with TestRun.step("Write data to exported object."):
         test_file_copy = test_file_main.copy(mnt_point + "test_file_copy")
@@ -105,9 +105,9 @@ def test_flush_over_640_gibibytes_with_fs(cache_mode, fs):
         if output.exit_code != 0:
             TestRun.fail(f"Stopping cache with flush failed!\n{output.stderr}")
 
-    with TestRun.step("Mount core device and check md5 sum of test file copy."):
+    with TestRun.step("Mount core device and check crc32 sum of test file copy."):
         core_dev.mount(mnt_point)
-        if test_file_md5sum_main != test_file_copy.md5sum():
+        if test_file_crc32sum_main != test_file_copy.crc32sum():
             TestRun.LOGGER.error("Md5 sums should be equal.")
 
     with TestRun.step("Delete test files."):

--- a/test/functional/tests/lazy_writes/test_flush_huge_dirty_data.py
+++ b/test/functional/tests/lazy_writes/test_flush_huge_dirty_data.py
@@ -86,10 +86,12 @@ def test_flush_over_640_gibibytes_with_fs(cache_mode, fs):
     with TestRun.step("Validate test file and read its crc32 sum."):
         if test_file_main.size != file_size:
             TestRun.fail("Created test file hasn't reached its target size.")
-        test_file_crc32sum_main = test_file_main.crc32sum()
+        test_file_crc32sum_main = test_file_main.crc32sum(timeout=timedelta(hours=4))
 
     with TestRun.step("Write data to exported object."):
-        test_file_copy = test_file_main.copy(mnt_point + "test_file_copy")
+        test_file_copy = test_file_main.copy(
+            mnt_point + "test_file_copy", timeout=timedelta(hours=4)
+        )
         test_file_copy.refresh_item()
         sync()
 
@@ -107,7 +109,7 @@ def test_flush_over_640_gibibytes_with_fs(cache_mode, fs):
 
     with TestRun.step("Mount core device and check crc32 sum of test file copy."):
         core_dev.mount(mnt_point)
-        if test_file_crc32sum_main != test_file_copy.crc32sum():
+        if test_file_crc32sum_main != test_file_copy.crc32sum(timeout=timedelta(hours=4)):
             TestRun.LOGGER.error("Md5 sums should be equal.")
 
     with TestRun.step("Delete test files."):


### PR DESCRIPTION
The test requires quite some space(640G) to prepare a file on a separate (not-cached) filesystem. Creating the file in rootfs is prone to (vague) errors due to limited space.

To make sure that the test has all the required space available, create the file on a separate disk