### PR TITLE
Fix mdadm --zero-superblock problem in cleanup

### DIFF
--- a/test/functional/tests/conftest.py
+++ b/test/functional/tests/conftest.py
@@ -262,7 +262,6 @@ def base_prepare(item):
                                disk_path in device.get_device_id(),
                                [bd.get_device_id() for bd in TestRun.dut.disks])),
                        raid.array_devices)):
-                raid.umount_all_partitions()
                 raid.remove_partitions()
                 raid.unmount()
                 raid.stop()
@@ -278,8 +277,6 @@ def base_prepare(item):
                     f"Serial for {disk.path} doesn't match the one from the config."
                     f"Serial from config {disk.serial_number}, actual serial {disk_serial}"
                 )
-
-            disk.umount_all_partitions()
             disk.remove_partitions()
             disk.unmount()
             Mdadm.zero_superblock(posixpath.join('/dev', disk.get_device_id()))

--- a/test/functional/tests/conftest.py
+++ b/test/functional/tests/conftest.py
@@ -264,6 +264,7 @@ def base_prepare(item):
                        raid.array_devices)):
                 raid.umount_all_partitions()
                 raid.remove_partitions()
+                raid.unmount()
                 raid.stop()
                 for device in raid.array_devices:
                     Mdadm.zero_superblock(posixpath.join('/dev', device.get_device_id()))
@@ -279,9 +280,9 @@ def base_prepare(item):
                 )
 
             disk.umount_all_partitions()
-            Mdadm.zero_superblock(posixpath.join('/dev', disk.get_device_id()))
-            TestRun.executor.run_expect_success("udevadm settle")
             disk.remove_partitions()
+            disk.unmount()
+            Mdadm.zero_superblock(posixpath.join('/dev', disk.get_device_id()))
             create_partition_table(disk, PartitionTable.gpt)
 
         TestRun.usr.already_updated = True


### PR DESCRIPTION
Cleanup handled mounted partitions but not the whole device