### PR TITLE
Fix error messages for metadata found during attach

### DIFF
--- a/casadm/cas_lib.c
+++ b/casadm/cas_lib.c
@@ -1,6 +1,6 @@
 /*
 * Copyright(c) 2012-2022 Intel Corporation
-* Copyright(c) 2024 Huawei Technologies
+* Copyright(c) 2024-2025 Huawei Technologies
 * SPDX-License-Identifier: BSD-3-Clause
 */
 
@@ -1025,6 +1025,22 @@ static int _start_cache(uint16_t cache_id, unsigned int cache_init,
 				cache_device);
 			} else {
 				print_err(cmd.ext_err_code);
+				if (OCF_ERR_METADATA_FOUND == cmd.ext_err_code) {
+					/* print instructions specific for start/attach */
+					if (start) {
+						cas_printf(LOG_ERR,
+							"Please load cache metadata using --load"
+							" option or use --force to\n discard on-disk"
+							" metadata and start fresh cache instance.\n"
+						);
+					} else {
+						cas_printf(LOG_ERR,
+							"Please attach another device or use --force"
+							" to discard on-disk metadata\n"
+							" and attach this device to cache instance.\n"
+						);
+					}
+				}
 			}
 			return FAILURE;
 		}

--- a/casadm/extended_err_msg.c
+++ b/casadm/extended_err_msg.c
@@ -1,6 +1,6 @@
 /*
 * Copyright(c) 2012-2022 Intel Corporation
-* Copyright(c) 2024 Huawei Technologies
+* Copyright(c) 2024-2025 Huawei Technologies
 * SPDX-License-Identifier: BSD-3-Clause
 */
 
@@ -151,9 +151,7 @@ struct {
 	},
 	{
 		OCF_ERR_METADATA_FOUND,
-		"Old metadata found on device.\nPlease load cache metadata using --load"
-		" option or use --force to\n discard on-disk metadata and"
-		" start fresh cache instance.\n"
+		"Old metadata found on device"
 	},
 	{
 		OCF_ERR_SUPERBLOCK_MISMATCH,

--- a/test/functional/api/cas/cli_messages.py
+++ b/test/functional/api/cas/cli_messages.py
@@ -6,8 +6,8 @@
 
 import re
 
-from core.test_run import TestRun
 from connection.utils.output import Output
+from core.test_run import TestRun
 
 load_inactive_core_missing = [
     r"WARNING: Can not resolve path to core \d+ from cache \d+\. By-id path will be shown for that "
@@ -17,9 +17,16 @@ load_inactive_core_missing = [
 
 start_cache_with_existing_metadata = [
     r"Error inserting cache \d+",
-    r"Old metadata found on device\.",
+    r"Old metadata found on device",
     r"Please load cache metadata using --load option or use --force to",
     r" discard on-disk metadata and start fresh cache instance\.",
+]
+
+attach_cache_with_existing_metadata = [
+    r"Error inserting cache \d+",
+    r"Old metadata found on device",
+    r"Please attach another device or use --force to discard on-disk metadata",
+    r" and attach this device to cache instance\.",
 ]
 
 start_cache_on_already_used_dev = [


### PR DESCRIPTION
Needs: [merged] https://github.com/Open-CAS/ocf/pull/863, otherwise 'invalid shutdown status bug' will hide this fix when using a detached cache device.
