### PR TITLE
chore(GH): Make GH ignore the test/ dir while detecting repo languages

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+test/* linguist-detectable=false


### PR DESCRIPTION
I think this should prevent GH from classifying this repo as coded mainly in Python. That might help with discoverability. 

P.S. I haven't really tested that as I'm on mobile ;)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Open-CAS/open-cas-linux/1612)
<!-- Reviewable:end -->
