### PR TITLE
Update .gitignore after manpage installation fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ modules.order
 __pycache__/
 *.py[cod]
 *$py.class
+*.gz
 
 casadm/casadm
 modules/include/ocf


### PR DESCRIPTION
New output files are created since https://github.com/Open-CAS/open-cas-linux/pull/1607 