### PR TITLE
tests/test-api: Fixes scope v25.3

### DIFF
--- a/test/functional/tests/basic/test_basic.py
+++ b/test/functional/tests/basic/test_basic.py
@@ -127,8 +127,8 @@ def test_data_integrity(filesystem, cache_mode, cache_line_size):
         cache_device = TestRun.disks["cache"]
         core_device = TestRun.disks["core"]
 
-        cache_device.create_partitions([Size(200, Unit.MebiByte)])
-        core_device.create_partitions([Size(100, Unit.MebiByte)])
+        cache_device.create_partitions([Size(600, Unit.MebiByte)])
+        core_device.create_partitions([Size(300, Unit.MebiByte)])
 
         cache_part = cache_device.partitions[0]
         core_part = core_device.partitions[0]

--- a/test/functional/tests/cache_ops/test_core_remove.py
+++ b/test/functional/tests/cache_ops/test_core_remove.py
@@ -1,6 +1,6 @@
 #
 # Copyright(c) 2020-2021 Intel Corporation
-# Copyright(c) 2024 Huawei Technologies Co., Ltd.
+# Copyright(c) 2024-2025 Huawei Technologies Co., Ltd.
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
@@ -35,8 +35,8 @@ def test_remove_core_when_other_mounted_auto_numeration():
         cache_device = TestRun.disks["cache"]
         core_device = TestRun.disks["core"]
 
-        cache_device.create_partitions([Size(50, Unit.MebiByte)])
-        core_device.create_partitions([Size(200, Unit.MebiByte)] * cores_amount)
+        cache_device.create_partitions([Size(100, Unit.MebiByte)])
+        core_device.create_partitions([Size(300, Unit.MebiByte)] * cores_amount)
 
     with TestRun.step("Start cache"):
         cache = casadm.start_cache(cache_device.partitions[0], force=True)
@@ -75,8 +75,8 @@ def test_remove_core_when_other_mounted_custom_numeration():
         cache_device = TestRun.disks["cache"]
         core_device = TestRun.disks["core"]
 
-        cache_device.create_partitions([Size(50, Unit.MebiByte)])
-        core_device.create_partitions([Size(200, Unit.MebiByte)] * 3)
+        cache_device.create_partitions([Size(100, Unit.MebiByte)])
+        core_device.create_partitions([Size(300, Unit.MebiByte)] * 3)
 
     with TestRun.step("Start cache"):
         cache = casadm.start_cache(cache_device.partitions[0], force=True)

--- a/test/functional/tests/cache_ops/test_dynamic_cache_mode_switching.py
+++ b/test/functional/tests/cache_ops/test_dynamic_cache_mode_switching.py
@@ -70,6 +70,10 @@ def test_cache_stop_and_load(cache_mode):
     with TestRun.step("Add core to the cache"):
         core = cache.add_core(core_dev.partitions[0])
 
+    with TestRun.step("Purge cache and reset cache counters"):
+        cache.purge_cache()
+        cache.reset_counters()
+
     with TestRun.step(f"Change cache mode to {cache_mode[1]}"):
         cache.set_cache_mode(cache_mode[1], flush=True)
         check_cache_config = cache.get_cache_config()

--- a/test/functional/tests/cache_ops/test_multistream_seq_cutoff.py
+++ b/test/functional/tests/cache_ops/test_multistream_seq_cutoff.py
@@ -28,7 +28,7 @@ from test_tools.udev import Udev
 from connection.utils.output import CmdException
 from type_def.size import Size, Unit
 
-random_thresholds = random.sample(range(1028, 1024**2, 4), 3)
+random_thresholds = random.sample(range(1028, 50*1024, 4), 3)
 random_stream_numbers = random.sample(range(2, 128), 3)
 mount_point = "/mnt"
 
@@ -37,7 +37,7 @@ mount_point = "/mnt"
 @pytest.mark.parametrizex("streams_number", [1, 128] + random_stream_numbers)
 @pytest.mark.parametrizex(
     "threshold",
-    [Size(1, Unit.MebiByte), Size(1, Unit.GibiByte)]
+    [Size(1, Unit.MebiByte)]
     + [Size(x, Unit.KibiByte) for x in random_thresholds],
 )
 @pytest.mark.require_disk("cache", DiskTypeSet([DiskType.optane, DiskType.nand]))

--- a/test/functional/tests/cache_ops/test_seq_cutoff.py
+++ b/test/functional/tests/cache_ops/test_seq_cutoff.py
@@ -75,6 +75,10 @@ def test_seq_cutoff_multi_core(cache_mode, io_type, io_type_last, cache_line_siz
         )
         core_list = [cache.add_core(core_dev=core_part) for core_part in core_parts]
 
+        with TestRun.step("Purge cache and reset cache counters"):
+            cache.purge_cache()
+            cache.reset_counters()
+
     with TestRun.step("Set sequential cutoff parameters for all cores"):
         writes_before_list = []
         fio_additional_size = Size(10, Unit.Blocks4096)
@@ -323,6 +327,10 @@ def test_seq_cutoff_thresh(cache_line_size, io_dir, policy, verify_type):
             unit=Unit.KibiByte,
         )
         io_size = (threshold + fio_additional_size).align_down(0x1000)
+
+    with TestRun.step("Purge cache and reset cache counters"):
+        cache.purge_cache()
+        cache.reset_counters()
 
     with TestRun.step(f"Setting cache sequential cutoff policy mode to {policy}"):
         cache.set_seq_cutoff_policy(policy)

--- a/test/functional/tests/ci/test_ci_read_write.py
+++ b/test/functional/tests/ci/test_ci_read_write.py
@@ -122,6 +122,10 @@ def test_ci_write_around_write():
                                    cache_mode=CacheMode.WA)
         casadm.add_core(cache, core_device)
 
+    with TestRun.step("Purge cache and reset cache counters"):
+        cache.purge_cache()
+        cache.reset_counters()
+
     with TestRun.step("Collect iostat before I/O"):
         iostat_core = IOstatBasic.get_iostat_list([core_device.parent_device.get_device_id()])
         write_core_0 = iostat_core[0].total_writes

--- a/test/functional/tests/cli/test_cleaning_policy.py
+++ b/test/functional/tests/cli/test_cleaning_policy.py
@@ -21,7 +21,7 @@ from test_tools.udev import Udev
 @pytest.mark.CI
 @pytest.mark.require_disk("cache", DiskTypeSet([DiskType.optane, DiskType.nand]))
 @pytest.mark.require_disk("core", DiskTypeLowerThan("cache"))
-def test_cleaning_policy():
+def test_cleaning_policy_change():
     """
     Title: Basic test for cleaning policy
     description: |

--- a/test/functional/tests/cli/test_manual_flush.py
+++ b/test/functional/tests/cli/test_manual_flush.py
@@ -22,7 +22,7 @@ from test_tools.udev import Udev
 @pytest.mark.CI
 @pytest.mark.require_disk("cache", DiskTypeSet([DiskType.optane, DiskType.nand]))
 @pytest.mark.require_disk("core", DiskTypeLowerThan("cache"))
-def test_cleaning_policy():
+def test_manual_flush():
     """
     title: Test for manual cache and core flushing
     description: |

--- a/test/functional/tests/fault_injection/test_fault_injection_with_mounted_core.py
+++ b/test/functional/tests/fault_injection/test_fault_injection_with_mounted_core.py
@@ -1,6 +1,6 @@
 #
 # Copyright(c) 2019-2022 Intel Corporation
-# Copyright(c) 2024 Huawei Technologies
+# Copyright(c) 2024-2025 Huawei Technologies
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
@@ -110,7 +110,7 @@ def test_stop_cache_with_mounted_partition():
         core2 = cache.add_core(core_dev2)
 
     with TestRun.step("Create partitions on one exported object."):
-        core.block_size = Size(get_block_size(core.get_device_id()))
+        core.block_size = Unit(get_block_size(core.get_device_id()))
         create_partitions(core, 2 * [Size(4, Unit.GibiByte)])
         fs_part = core.partitions[0]
 

--- a/test/functional/tests/fault_injection/test_fault_power_reboot.py
+++ b/test/functional/tests/fault_injection/test_fault_power_reboot.py
@@ -1,6 +1,6 @@
 #
 # Copyright(c) 2022 Intel Corporation
-# Copyright(c) 2024 Huawei Technologies
+# Copyright(c) 2024-2025 Huawei Technologies
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
@@ -51,7 +51,7 @@ def test_fault_power_reboot():
 
     with TestRun.step("Hard reset."):
         power_control = TestRun.plugin_manager.get_plugin('power_control')
-        power_control.power_cycle()
+        power_control.power_cycle(wait_for_connection=True)
 
     with TestRun.step("Start cache without re-initialization."):
         output = TestRun.executor.run_expect_fail(cli.start_cmd(

--- a/test/functional/tests/fault_injection/test_soft_hot_plug_device.py
+++ b/test/functional/tests/fault_injection/test_soft_hot_plug_device.py
@@ -1,6 +1,6 @@
 #
 # Copyright(c) 2019-2022 Intel Corporation
-# Copyright(c) 2024 Huawei Technologies Co., Ltd.
+# Copyright(c) 2024-2025 Huawei Technologies Co., Ltd.
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
@@ -88,9 +88,6 @@ def test_soft_hot_unplug_cache(cache_mode):
                 f"There are some inconsistencies in error stats "
                 f"for {cache_mode} cache mode:\n{failed_errors}"
             )
-
-    with TestRun.step("Stop all caches"):
-        casadm.stop_all_caches()
 
     with TestRun.step("Plug back cache device"):
         cache_dev.plug_all()

--- a/test/functional/tests/incremental_load/test_inactive_cores.py
+++ b/test/functional/tests/incremental_load/test_inactive_cores.py
@@ -8,7 +8,7 @@ import pytest
 
 from api.cas import casadm
 from api.cas.cache_config import CacheMode
-from api.cas.casadm_parser import get_cas_devices_dict
+from api.cas.casadm_parser import get_cas_devices_dict, get_inactive_cores
 from api.cas.core import Core, CoreStatus
 from core.test_run import TestRun
 from storage_devices.disk import DiskType, DiskTypeSet, DiskTypeLowerThan
@@ -239,17 +239,3 @@ def test_core_inactive_stats_usage():
                 f"{cache_usage_stats.inactive_clean}\n"
                 f"Expected number of clean blocks percentage: {inactive_cores_clean_stats}"
             )
-
-
-def get_inactive_cores(cache_id: int) -> list:
-    cores_dict = get_cas_devices_dict()["cores"].values()
-
-    def is_active(core):
-
-        return CoreStatus[core["status"].lower()] == CoreStatus.inactive
-
-    return [
-        Core(core["device_path"], core["cache_id"])
-        for core in cores_dict
-        if is_active(core) and core["cache_id"] == cache_id
-    ]

--- a/test/functional/tests/incremental_load/test_udev.py
+++ b/test/functional/tests/incremental_load/test_udev.py
@@ -1,6 +1,6 @@
 #
 # Copyright(c) 2020-2021 Intel Corporation
-# Copyright(c) 2024 Huawei Technologies Co., Ltd.
+# Copyright(c) 2024-2025 Huawei Technologies Co., Ltd.
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
@@ -283,7 +283,7 @@ def test_neg_udev_cache_load():
             TestRun.LOGGER.error(f"There is wrong number of caches. Expected: 1, actual: "
                                  f"{len(cas_devices['caches'])}")
         elif cas_devices["caches"][1]["device_path"] != cache_disk.partitions[0].path or \
-                CacheStatus[(cas_devices["caches"][1]["status"]).lower()] != CacheStatus.running:
+                cas_devices["caches"][1]["status"] != CacheStatus.running:
             TestRun.LOGGER.error(f"Cache did not load properly: {cas_devices['caches'][1]}")
         if len(cas_devices["cores"]) != 2:
             TestRun.LOGGER.error(f"There is wrong number of cores. Expected: 2, actual: "
@@ -294,7 +294,7 @@ def test_neg_udev_cache_load():
             correct_core_devices.append(core_disk.partitions[i].path)
         for core in cas_devices["cores"].values():
             if core["device_path"] not in correct_core_devices or \
-                    CoreStatus[core["status"].lower()] != CoreStatus.active or \
+                    core["status"] != CoreStatus.active or \
                     core["cache_id"] != 1:
                 TestRun.LOGGER.error(f"Core did not load correctly: {core}.")
 

--- a/test/functional/tests/incremental_load/test_udev.py
+++ b/test/functional/tests/incremental_load/test_udev.py
@@ -16,6 +16,7 @@ from api.cas.init_config import InitConfig
 from core.test_run import TestRun
 from storage_devices.disk import DiskTypeSet, DiskType
 from storage_devices.raid import RaidConfiguration, Raid, Level, MetadataVariant
+from test_tools.udev import Udev
 from type_def.size import Size, Unit
 
 
@@ -121,6 +122,7 @@ def test_udev_core():
 
     with TestRun.step("Plug cache disk."):
         cache_disk.plug_all()
+        Udev.settle()
 
     with TestRun.step("Check if core device is active and not in the core pool."):
         check_if_dev_in_core_pool(core_dev, False)

--- a/test/functional/tests/initialize/test_clean_reboot.py
+++ b/test/functional/tests/initialize/test_clean_reboot.py
@@ -1,6 +1,6 @@
 #
 # Copyright(c) 2020-2022 Intel Corporation
-# Copyright(c) 2024 Huawei Technologies Co., Ltd.
+# Copyright(c) 2024-2025 Huawei Technologies Co., Ltd.
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
@@ -75,7 +75,7 @@ def test_load_after_clean_shutdown(reboot_type, cache_mode, filesystem):
             TestRun.executor.reboot()
         else:
             power_control = TestRun.plugin_manager.get_plugin("power_control")
-            power_control.power_cycle()
+            power_control.power_cycle(wait_for_connection=True)
 
     with TestRun.step("Load cache and mount core"):
         casadm.load_cache(cache_dev)

--- a/test/functional/tests/initialize/test_startup_init_config.py
+++ b/test/functional/tests/initialize/test_startup_init_config.py
@@ -338,12 +338,11 @@ def test_cas_startup_negative_missing_core():
 
     escape = EmergencyEscape()
     escape.add_escape_method_command("/usr/bin/rm /etc/opencas/opencas.conf")
-    set_cas_service_timeout(timedelta(seconds=10))
+    set_cas_service_timeout(timedelta(minutes=1))
 
     with TestRun.step("Reboot DUT with emergency escape armed"):
         with escape:
             TestRun.executor.reboot()
-            TestRun.executor.wait_for_connection()
 
     with TestRun.step("Verify the DUT entered emergency mode"):
         dmesg_out = TestRun.executor.run_expect_success("dmesg").stdout.split("\n")
@@ -352,6 +351,10 @@ def test_cas_startup_negative_missing_core():
 
     clear_cas_service_timeout()
     InitConfig().create_default_init_config()
+
+    # required to fix services after test
+    with TestRun.step("Reboot platform"):
+        TestRun.executor.reboot()
 
 
 @pytest.mark.os_dependent
@@ -427,6 +430,10 @@ def test_cas_startup_negative_missing_cache():
 
     clear_cas_service_timeout()
     InitConfig().create_default_init_config()
+
+    # required to fix services after test
+    with TestRun.step("Reboot platform"):
+        TestRun.executor.reboot()
 
 
 @pytest.mark.os_dependent

--- a/test/functional/tests/initialize/test_startup_init_config.py
+++ b/test/functional/tests/initialize/test_startup_init_config.py
@@ -419,7 +419,6 @@ def test_cas_startup_negative_missing_cache():
     with TestRun.step("Reboot DUT with emergency escape armed"):
         with escape:
             TestRun.executor.reboot()
-            TestRun.executor.wait_for_connection()
 
     with TestRun.step("Verify the DUT entered emergency mode"):
         dmesg_out = TestRun.executor.run_expect_success("dmesg").stdout.split("\n")

--- a/test/functional/tests/initialize/test_startup_init_config.py
+++ b/test/functional/tests/initialize/test_startup_init_config.py
@@ -76,9 +76,7 @@ def test_cas_startup(cache_mode, filesystem):
         md5_before = test_file.md5sum()
 
     with TestRun.step("Add mountpoint fstab and create intelcas.conf"):
-        fstab.add_mountpoint(device=core,
-                             mount_point=mountpoint,
-                             fs_type=filesystem)
+        fstab.add_mountpoint(device=core, mount_point=mountpoint, fs_type=filesystem)
         InitConfig.create_init_config_from_running_configuration()
 
     with TestRun.step("Reboot"):
@@ -116,11 +114,16 @@ def test_cas_startup(cache_mode, filesystem):
 
 @pytest.mark.require_disk("cache", DiskTypeSet([DiskType.optane, DiskType.nand]))
 @pytest.mark.require_disk("core", DiskTypeLowerThan("cache"))
-@pytest.mark.parametrizex("cache_mode_pair", [(CacheMode.WT, CacheMode.WB),
-                                              (CacheMode.WB, CacheMode.WA),
-                                              (CacheMode.WA, CacheMode.PT),
-                                              (CacheMode.PT, CacheMode.WO),
-                                              (CacheMode.WO, CacheMode.WT)])
+@pytest.mark.parametrizex(
+    "cache_mode_pair",
+    [
+        (CacheMode.WT, CacheMode.WB),
+        (CacheMode.WB, CacheMode.WA),
+        (CacheMode.WA, CacheMode.PT),
+        (CacheMode.PT, CacheMode.WO),
+        (CacheMode.WO, CacheMode.WT),
+    ],
+)
 def test_cas_init_with_changed_mode(cache_mode_pair):
     """
     title: Check starting cache in other cache mode by initializing OpenCAS service from config.
@@ -180,18 +183,26 @@ def test_cas_startup_lazy():
         cache_disk.create_partitions([Size(200, Unit.MebiByte)] * 2)
         core_disk.create_partitions([Size(200, Unit.MebiByte)] * 4)
 
-    with TestRun.step(f"Add a cache configuration with cache device with `lazy_startup` flag"):
+    with TestRun.step(
+        f"Add a cache configuration with cache device with `lazy_startup` flag"
+    ):
         init_conf = InitConfig()
-        init_conf.add_cache(1, cache_disk.partitions[0], extra_flags="lazy_startup=True")
+        init_conf.add_cache(
+            1, cache_disk.partitions[0], extra_flags="lazy_startup=True"
+        )
         init_conf.add_core(1, 1, core_disk.partitions[0])
         init_conf.add_core(1, 2, core_disk.partitions[1])
 
         expected_core_pool_paths = set(c.path for c in core_disk.partitions[:2])
 
-    with TestRun.step(f"Add a cache configuration with core device with `lazy_startup` flag"):
+    with TestRun.step(
+        f"Add a cache configuration with core device with `lazy_startup` flag"
+    ):
         init_conf.add_cache(2, cache_disk.partitions[1])
         init_conf.add_core(2, 1, core_disk.partitions[2])
-        init_conf.add_core(2, 2, core_disk.partitions[3], extra_flags="lazy_startup=True")
+        init_conf.add_core(
+            2, 2, core_disk.partitions[3], extra_flags="lazy_startup=True"
+        )
         init_conf.save_config_file()
         sync()
 
@@ -200,10 +211,14 @@ def test_cas_startup_lazy():
         active_core_path = core_disk.partitions[2].path
         inactive_core_path = core_disk.partitions[3].path
 
-    with TestRun.step(f"Start and stop all the configurations using the casctl utility"):
+    with TestRun.step(
+        f"Start and stop all the configurations using the casctl utility"
+    ):
         output = casctl.init(True)
         if output.exit_code != 0:
-            TestRun.fail(f"Failed to initialize caches from config file. Error: {output.stdout}")
+            TestRun.fail(
+                f"Failed to initialize caches from config file. Error: {output.stdout}"
+            )
         casadm.stop_all_caches()
 
     with TestRun.step(
@@ -282,23 +297,35 @@ def test_cas_startup_negative_missing_core():
         cache_disk.create_partitions([Size(200, Unit.MebiByte)] * 2)
         core_disk.create_partitions([Size(200, Unit.MebiByte)] * 4)
 
-    with TestRun.step(f"Add a cache configuration with cache device with `lazy_startup` flag"):
+    with TestRun.step(
+        f"Add a cache configuration with cache device with `lazy_startup` flag"
+    ):
         init_conf = InitConfig()
-        init_conf.add_cache(1, cache_disk.partitions[0], extra_flags="lazy_startup=True")
+        init_conf.add_cache(
+            1, cache_disk.partitions[0], extra_flags="lazy_startup=True"
+        )
         init_conf.add_core(1, 1, core_disk.partitions[0])
         init_conf.add_core(1, 2, core_disk.partitions[1])
 
-    with TestRun.step(f"Add a cache configuration with core device with `lazy_startup` flag"):
+    with TestRun.step(
+        f"Add a cache configuration with core device with `lazy_startup` flag"
+    ):
         init_conf.add_cache(2, cache_disk.partitions[1])
         init_conf.add_core(2, 1, core_disk.partitions[2])
-        init_conf.add_core(2, 2, core_disk.partitions[3], extra_flags="lazy_startup=True")
+        init_conf.add_core(
+            2, 2, core_disk.partitions[3], extra_flags="lazy_startup=True"
+        )
         init_conf.save_config_file()
         sync()
 
-    with TestRun.step(f"Start and stop all the configurations using the casctl utility"):
+    with TestRun.step(
+        f"Start and stop all the configurations using the casctl utility"
+    ):
         output = casctl.init(True)
         if output.exit_code != 0:
-            TestRun.fail(f"Failed to initialize caches from config file. Error: {output.stdout}")
+            TestRun.fail(
+                f"Failed to initialize caches from config file. Error: {output.stdout}"
+            )
         casadm.stop_all_caches()
 
     with TestRun.step(
@@ -344,23 +371,37 @@ def test_cas_startup_negative_missing_cache():
         cache_disk.create_partitions([Size(200, Unit.MebiByte)] * 2)
         core_disk.create_partitions([Size(200, Unit.MebiByte)] * 4)
 
-    with TestRun.step(f"Add a cache configuration with cache device with `lazy_startup` flag"):
+    with TestRun.step(
+        f"Add a cache configuration with cache device with `lazy_startup` flag"
+    ):
         init_conf = InitConfig()
-        init_conf.add_cache(1, cache_disk.partitions[0], extra_flags="lazy_startup=True")
+        init_conf.add_cache(
+            1, cache_disk.partitions[0], extra_flags="lazy_startup=True"
+        )
         init_conf.add_core(1, 1, core_disk.partitions[0])
         init_conf.add_core(1, 2, core_disk.partitions[1])
 
-    with TestRun.step(f"Add a cache configuration with core devices with `lazy_startup` flag"):
+    with TestRun.step(
+        f"Add a cache configuration with core devices with `lazy_startup` flag"
+    ):
         init_conf.add_cache(2, cache_disk.partitions[1])
-        init_conf.add_core(2, 1, core_disk.partitions[2], extra_flags="lazy_startup=True")
-        init_conf.add_core(2, 2, core_disk.partitions[3], extra_flags="lazy_startup=True")
+        init_conf.add_core(
+            2, 1, core_disk.partitions[2], extra_flags="lazy_startup=True"
+        )
+        init_conf.add_core(
+            2, 2, core_disk.partitions[3], extra_flags="lazy_startup=True"
+        )
         init_conf.save_config_file()
         sync()
 
-    with TestRun.step(f"Start and stop all the configurations using the casctl utility"):
+    with TestRun.step(
+        f"Start and stop all the configurations using the casctl utility"
+    ):
         output = casctl.init(True)
         if output.exit_code != 0:
-            TestRun.fail(f"Failed to initialize caches from config file. Error: {output.stdout}")
+            TestRun.fail(
+                f"Failed to initialize caches from config file. Error: {output.stdout}"
+            )
         casadm.stop_all_caches()
 
     with TestRun.step(
@@ -435,10 +476,14 @@ def test_failover_config_startup():
         init_conf.save_config_file()
         sync()
 
-    with TestRun.step(f"Start and stop all the configurations using the casctl utility"):
+    with TestRun.step(
+        f"Start and stop all the configurations using the casctl utility"
+    ):
         output = casctl.init(True)
         if output.exit_code != 0:
-            TestRun.fail(f"Failed to initialize caches from config file. Error: {output.stdout}")
+            TestRun.fail(
+                f"Failed to initialize caches from config file. Error: {output.stdout}"
+            )
         casadm.stop_all_caches()
 
     with TestRun.step("Reboot DUT"):
@@ -451,7 +496,9 @@ def test_failover_config_startup():
         cores_list = casadm_parser.get_cas_devices_dict()["cores"].values()
 
         if len(core_pool_list) != 0:
-            TestRun.LOGGER.error(f"No cores expected in core pool. Got {core_pool_list}")
+            TestRun.LOGGER.error(
+                f"No cores expected in core pool. Got {core_pool_list}"
+            )
         else:
             TestRun.LOGGER.info("Core pool is ok")
 
@@ -518,15 +565,19 @@ def test_failover_config_startup_negative():
         init_conf.add_cache(
             1,
             cache_disk.partitions[0],
-            extra_flags="target_failover_state=standby,cache_line_size=4"
+            extra_flags="target_failover_state=standby,cache_line_size=4",
         )
         init_conf.save_config_file()
         sync()
 
-    with TestRun.step(f"Start and stop all the configurations using the casctl utility"):
+    with TestRun.step(
+        f"Start and stop all the configurations using the casctl utility"
+    ):
         output = casctl.init(True)
         if output.exit_code != 0:
-            TestRun.fail(f"Failed to initialize caches from config file. Error: {output.stdout}")
+            TestRun.fail(
+                f"Failed to initialize caches from config file. Error: {output.stdout}"
+            )
         casadm.stop_all_caches()
 
     with TestRun.step(
@@ -566,7 +617,9 @@ def validate_cache(cache_mode):
     cores = casadm_parser.get_cores(caches[0].cache_id)
     cores_count = len(cores)
     if cores_count != 1:
-        TestRun.LOGGER.error(f"Cache started with wrong number of cores: {cores_count}.")
+        TestRun.LOGGER.error(
+            f"Cache started with wrong number of cores: {cores_count}."
+        )
 
     current_mode = caches[0].get_cache_mode()
     if current_mode != cache_mode:
@@ -609,8 +662,7 @@ def test_lazy_startup_core_path_by_id(cache_mode, reboot_type):
 
     with TestRun.step("Create init config file"):
         InitConfig.create_init_config_from_running_configuration(
-            cache_extra_flags="lazy_startup=true",
-            core_extra_flags="lazy_startup=true"
+            cache_extra_flags="lazy_startup=true", core_extra_flags="lazy_startup=true"
         )
 
     with TestRun.step("Stop cache and clear metadata before reboot"):
@@ -620,8 +672,8 @@ def test_lazy_startup_core_path_by_id(cache_mode, reboot_type):
     with TestRun.step("Reset platform"):
         if reboot_type == "soft":
             TestRun.executor.reboot()
-        else:           # wait few seconds to simulate power failure during normal system run
-            sleep(5)    # not when configuring Open CAS
+        else:  # wait few seconds to simulate power failure during normal system run
+            sleep(5)  # not when configuring Open CAS
             power_control = TestRun.plugin_manager.get_plugin("power_control")
             power_control.power_cycle(wait_for_connection=True)
 
@@ -671,7 +723,9 @@ def test_lazy_startup_core_path_not_by_id(cache_mode, reboot_type):
         cores = [cache.add_core(partition) for partition in core_dev.partitions]
 
     with TestRun.step("Create init config file"):
-        create_init_config(cache, cores, [readlink(part.path) for part in core_dev.partitions])
+        create_init_config(
+            cache, cores, [readlink(part.path) for part in core_dev.partitions]
+        )
 
     with TestRun.step("Stop cache and clear metadata before reboot"):
         cache.stop()
@@ -680,8 +734,8 @@ def test_lazy_startup_core_path_not_by_id(cache_mode, reboot_type):
     with TestRun.step("Reset platform"):
         if reboot_type == "soft":
             TestRun.executor.reboot()
-        else:           # wait few seconds to simulate power failure during normal system run
-            sleep(5)    # not when configuring Open CAS
+        else:  # wait few seconds to simulate power failure during normal system run
+            sleep(5)  # not when configuring Open CAS
             power_control = TestRun.plugin_manager.get_plugin("power_control")
             power_control.power_cycle(wait_for_connection=True)
 
@@ -697,6 +751,6 @@ def create_init_config(cache, cores, paths):
     )
     for core, path in zip(cores, paths):
         params = [str(cache.cache_id), str(core.core_id), path, "lazy_startup=true"]
-        init_conf.core_config_lines.append('\t'.join(params))
+        init_conf.core_config_lines.append("\t".join(params))
     init_conf.save_config_file()
     return init_conf

--- a/test/functional/tests/io_class/test_io_class_pinning_eviction.py
+++ b/test/functional/tests/io_class/test_io_class_pinning_eviction.py
@@ -1,6 +1,6 @@
 #
 # Copyright(c) 2022 Intel Corporation
-# Copyright(c) 2024 Huawei Technologies Co., Ltd.
+# Copyright(c) 2024-2025 Huawei Technologies
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
@@ -36,7 +36,8 @@ def test_io_class_pinning_eviction():
         Check Open CAS ability to prevent from eviction of pinned IoClass - stress test.
     pass_criteria:
         - IoClasses loaded successfully
-        - Pinned class occupies the same ammount of cache after each IO operation on different IoClass
+        - Pinned class occupies the same amount of cache after each IO operation on different
+          IO class
     """
 
     with TestRun.step("Prepare devices"):
@@ -119,7 +120,8 @@ def test_io_class_pinning_eviction():
             after_op_occupancy = get_io_class_occupancy(cache, pinned_io_class.id)
             if pinned_occupancy != after_op_occupancy:
                 TestRun.fail(
-                    f"Pinned IO class do not occupy all of their space. Expected:{pinned_occupancy} Actual:{after_op_occupancy}"
+                    f"Pinned IO class do not occupy all of their space.\nExpected:"
+                    f"{pinned_occupancy}\nActual:{after_op_occupancy}"
                 )
 
 
@@ -133,7 +135,8 @@ def test_pinned_ioclasses_eviction():
         into another pinned IoClass.
     pass_criteria:
         - IoClasses loaded successfully
-        - First pinned class occupies the same ammount of cache after IO operation on another pinned IoClass
+        - First pinned class occupies the same amount of cache after IO operation on another pinned
+          IO class
     """
 
     with TestRun.step("Prepare devices"):

--- a/test/functional/tests/lazy_writes/recovery/recovery_tests_methods.py
+++ b/test/functional/tests/lazy_writes/recovery/recovery_tests_methods.py
@@ -1,6 +1,6 @@
 #
 # Copyright(c) 2020-2022 Intel Corporation
-# Copyright(c) 2024 Huawei Technologies Co., Ltd.
+# Copyright(c) 2024-2025 Huawei Technologies Co., Ltd.
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
@@ -54,4 +54,4 @@ def power_cycle_dut(wait_for_flush_begin=False, core_device=None):
             timedelta(milliseconds=100)
         )
     power_control = TestRun.plugin_manager.get_plugin('power_control')
-    power_control.power_cycle()
+    power_control.power_cycle(wait_for_connection=True)

--- a/test/functional/tests/lazy_writes/test_dirty_load.py
+++ b/test/functional/tests/lazy_writes/test_dirty_load.py
@@ -1,6 +1,6 @@
 #
 # Copyright(c) 2021 Intel Corporation
-# Copyright(c) 2024 Huawei Technologies Co., Ltd.
+# Copyright(c) 2024-2025 Huawei Technologies Co., Ltd.
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
@@ -62,7 +62,7 @@ def test_dirty_load():
 
     with TestRun.step("Reset platform."):
         power_control = TestRun.plugin_manager.get_plugin('power_control')
-        power_control.power_cycle()
+        power_control.power_cycle(wait_for_connection=True)
 
     with TestRun.step("Load cache."):
         cache = casadm.load_cache(cache_dev)

--- a/test/functional/tests/stats/test_block_stats.py
+++ b/test/functional/tests/stats/test_block_stats.py
@@ -1,6 +1,6 @@
 #
 # Copyright(c) 2019-2021 Intel Corporation
-# Copyright(c) 2024 Huawei Technologies Co., Ltd.
+# Copyright(c) 2024-2025 Huawei Technologies Co., Ltd.
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
@@ -56,6 +56,7 @@ def test_block_stats_write_miss(cache_mode: CacheMode):
         cores = [cache.add_core(part) for part in core_device.partitions]
 
     with TestRun.step("Reset cache stats"):
+        cache.purge_cache()
         cache.reset_counters()
 
     with TestRun.step("Write data in parts to exported objects and verify block statistics "
@@ -164,6 +165,7 @@ def test_block_stats_read_miss(cache_mode: CacheMode):
         cores = [cache.add_core(part) for part in core_device.partitions]
 
     with TestRun.step("Reset cache stats"):
+        cache.purge_cache()
         cache.reset_counters()
 
     with TestRun.step("Read data in parts from exported objects and verify block statistics "

--- a/test/functional/tests/stress/test_stress_shutdown.py
+++ b/test/functional/tests/stress/test_stress_shutdown.py
@@ -1,6 +1,6 @@
 #
 # Copyright(c) 2020-2021 Intel Corporation
-# Copyright(c) 2024 Huawei Technologies Co., Ltd.
+# Copyright(c) 2024-2025 Huawei Technologies Co., Ltd.
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
@@ -66,7 +66,7 @@ def test_stress_dirty_shutdown(cache_line_size, cache_mode, cleaning_policy):
 
         with TestRun.step("Reset platform."):
             power_control = TestRun.plugin_manager.get_plugin('power_control')
-            power_control.power_cycle()
+            power_control.power_cycle(wait_for_connection=True)
 
         with TestRun.step("Check configuration after load."):
             check_configuration(cleaning_policy, cache_mode, cache_line_size)

--- a/test/functional/tests/volumes/test_many_lvms_on_many_cores.py
+++ b/test/functional/tests/volumes/test_many_lvms_on_many_cores.py
@@ -97,7 +97,3 @@ def test_many_lvms_on_many_cores(update_initramfs_before_and_after_test):
 
     with TestRun.step("Run FIO with verification on LVM."):
         fio_run.run()
-
-    with TestRun.step("Remove LVMs and clean up config changes."):
-        Lvm.remove_all()
-        LvmConfiguration.remove_filters_from_config()


### PR DESCRIPTION
General info - Newer Kernels require at least 300MB device/partition for xfs filesystem
Add udev settle - sometimes, during local/remote test execution, udev was not fast enough to attach the disk to the cache. Added settle so we gonna give udev time before checking casadm list output
Update the ioclass test after discussion with the development team - test_ioclass_file_name_prefix
Update CacheStatus usage in tests (after api changes)
