### PR TITLE
Fixes for data integrity long tests

### DIFF
--- a/test/functional/tests/data_integrity/test_data_integrity_5d.py
+++ b/test/functional/tests/data_integrity/test_data_integrity_5d.py
@@ -1,31 +1,30 @@
 #
 # Copyright(c) 2019-2021 Intel Corporation
-# Copyright(c) 2024 Huawei Technologies Co., Ltd.
+# Copyright(c) 2024-2025 Huawei Technologies Co., Ltd.
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
 import random
 import datetime
 import itertools
-
+import re
 import pytest
+
+from datetime import timedelta
 
 from api.cas import casadm
 from api.cas.cache_config import CacheMode
+from api.cas.ioclass_config import IoClass
 from core.test_run import TestRun
-from test_tools.fs_tools import Filesystem, create_directory, check_if_directory_exists, md5sum
+from test_tools.fs_tools import Filesystem, create_directory, check_if_directory_exists, \
+    read_file, crc32sum
 from test_tools.fio.fio import Fio
 from test_tools.fio.fio_param import ReadWrite, IoEngine, VerifyMethod
 from storage_devices.disk import DiskType, DiskTypeSet, DiskTypeLowerThan
 from test_tools.os_tools import sync
 from type_def.size import Unit, Size
 
-
-start_size = Size(512, Unit.Byte).get_value()
-stop_size = Size(128, Unit.KibiByte).get_value()
-file_min_size = Size(4, Unit.KibiByte).get_value()
-file_max_size = Size(2, Unit.GibiByte).get_value()
-runtime = datetime.timedelta(days=5)
+template_config_path = "/etc/opencas/ioclass-config.csv"
 
 
 def shuffled_fs_list(n):
@@ -39,85 +38,130 @@ def shuffled_fs_list(n):
 @pytest.mark.require_disk("core3", DiskTypeLowerThan("cache"))
 @pytest.mark.require_disk("core4", DiskTypeLowerThan("cache"))
 @pytest.mark.parametrize("filesystems", [shuffled_fs_list(4)])
-def test_data_integrity_5d_dss(filesystems):
+def test_data_integrity_5d_with_io_classification(filesystems):
     """
-        title: |
-          Data integrity test on three cas instances with different
-          file systems with duration time equal to 5 days
-        description: |
-          Create 3 cache instances on caches equal to 50GB and cores equal to 150GB
-          with different file systems, and run workload with data verification.
-        pass_criteria:
-            - System does not crash.
-            - All operations complete successfully.
-            - Data consistency is being preserved.
+    title: Data integrity long test with I/O classification.
+    description: |
+        Test running workload with data verification and I/O classification by file size
+        on multiple cache instances with different cache modes and filesystems.
+    pass_criteria:
+      - System does not crash.
+      - All operations complete successfully.
+      - Data consistency is being preserved.
     """
+    cache_modes = [CacheMode.WT, CacheMode.WB, CacheMode.WA, CacheMode.WO]
+    runtime = datetime.timedelta(days=5)
+
     with TestRun.step("Prepare cache and core devices"):
-        cache_devices, core_devices = prepare_devices()
+        cache_device = TestRun.disks['cache']
+        core_devices = [TestRun.disks['core1'],
+                        TestRun.disks['core2'],
+                        TestRun.disks['core3'],
+                        TestRun.disks['core4']]
 
-    with TestRun.step("Run 4 cache instances in different cache modes, add single core to each"):
-        cache_modes = [CacheMode.WT, CacheMode.WB, CacheMode.WA, CacheMode.WO]
-        caches = []
-        cores = []
-        for i in range(4):
-            cache, core = start_instance(cache_devices[i], core_devices[i], cache_modes[i])
-            caches.append(cache)
-            cores.append(core)
+        cache_device.create_partitions([Size(50, Unit.GibiByte)] * len(core_devices))
 
-    with TestRun.step("Load default io class config for each cache"):
+        core_partitions = []
+        core_size = Size(150, Unit.GibiByte)
+        for core_dev in core_devices:
+            core_dev.create_partitions([core_size])
+            core_partitions.append(core_dev.partitions[0])
+        sync()
+
+    with TestRun.step("Start caches, each in other cache mode"):
+        caches = [
+            casadm.start_cache(cache_dev=cache_part, cache_mode=cache_mode, force=True)
+            for cache_part, cache_mode in zip(cache_device.partitions, cache_modes)
+        ]
+
+    with TestRun.step("Add one core to each cache"):
+        cores = [
+            cache.add_core(core_dev=core_part)
+            for cache, core_part in zip(caches, core_partitions)
+        ]
+
+    with TestRun.step("Load default I/O class config for each cache"):
         for cache in caches:
-            cache.load_io_class("/etc/opencas/ioclass-config.csv")
+            cache.load_io_class(template_config_path)
 
-    with TestRun.step("Create filesystems and mount cores"):
-        for i, core in enumerate(cores):
+    with TestRun.step("Create filesystems on exported objects"):
+        for filesystem, core in zip(filesystems, cores):
+            core.create_filesystem(fs_type=filesystem)
+
+    with TestRun.step("Mount cached volumes"):
+        for core in cores:
             mount_point = core.path.replace('/dev/', '/mnt/')
             if not check_if_directory_exists(mount_point):
                 create_directory(mount_point)
-            TestRun.LOGGER.info(f"Create filesystem {filesystems[i].name} on {core.path}")
-            core.create_filesystem(filesystems[i])
-            TestRun.LOGGER.info(f"Mount filesystem {filesystems[i].name} on {core.path} to "
-                                f"{mount_point}")
             core.mount(mount_point)
             sync()
 
-    with TestRun.step("Run test workloads on filesystems with verification"):
-        fio_run = Fio().create_command()
+    with TestRun.step("Prepare fio workload config"):
+        template_io_classes = IoClass.csv_to_list(read_file(template_config_path))
+        config_max_file_sizes = [
+            int(re.search(r'\d+', io_class.rule).group())
+            for io_class in template_io_classes if io_class.rule.startswith("file_size:le")
+        ]
+        config_max_file_sizes.append(config_max_file_sizes[-1] * 2)
+        io_class_section_size = Size(
+            int(core_size.get_value(Unit.GibiByte) / len(config_max_file_sizes)),
+            Unit.GibiByte
+        )
+
+        fio = Fio()
+        fio_run = fio.create_command()
+        fio.base_cmd_parameters.set_param(
+            'alloc-size', int(Size(1, Unit.GiB).get_value(Unit.KiB))
+        )
+
         fio_run.io_engine(IoEngine.libaio)
         fio_run.direct()
         fio_run.time_based()
-        fio_run.nr_files(4096)
-        fio_run.file_size_range([(file_min_size, file_max_size)])
         fio_run.do_verify()
         fio_run.verify(VerifyMethod.md5)
         fio_run.verify_dump()
         fio_run.run_time(runtime)
         fio_run.read_write(ReadWrite.randrw)
         fio_run.io_depth(128)
-        fio_run.blocksize_range([(start_size, stop_size)])
+        fio_run.blocksize_range(
+            [(Size(512, Unit.Byte).get_value(), Size(128, Unit.KibiByte).get_value())]
+        )
+
         for core in cores:
-            fio_job = fio_run.add_job()
-            fio_job.directory(core.mount_point)
-            fio_job.size(core.size)
-        fio_run.run()
+            min_file_size = 512
+            for max_file_size in config_max_file_sizes:
+                # 10000 limit of files for reasonable time of preparation ~2hours
+                nr_files = min(10000, int(io_class_section_size * 0.9 / max_file_size))
+
+                fio_job = fio_run.add_job()
+                fio_job.directory(core.mount_point)
+                fio_job.nr_files(nr_files)
+                fio_job.file_size_range([(min_file_size, max_file_size)])
+                min_file_size = max_file_size
+
+    with TestRun.step("Run test workload on filesystems with verification"):
+        fio_run.run(fio_timeout=runtime + datetime.timedelta(hours=3))
 
     with TestRun.step("Unmount cores"):
         for core in cores:
             core.unmount()
 
-    with TestRun.step("Calculate md5 for each core"):
-        core_md5s = [md5sum(core.path) for core in cores]
+    with TestRun.step("Calculate crc32 for each core"):
+        core_crc32s = [crc32sum(core.path, timeout=timedelta(hours=4)) for core in cores]
 
     with TestRun.step("Stop caches"):
         for cache in caches:
             cache.stop()
 
-    with TestRun.step("Calculate md5 for each core"):
-        dev_md5s = [md5sum(dev.full_path) for dev in core_devices]
+    with TestRun.step("Calculate crc32 for each core"):
+        dev_crc32s = [crc32sum(dev.path, timeout=timedelta(hours=4)) for dev in core_devices]
 
-    with TestRun.step("Compare md5 sums for cores and core devices"):
-        for core_md5, dev_md5, mode, fs in zip(core_md5s, dev_md5s, cache_modes, filesystems):
-            if core_md5 != dev_md5:
-                TestRun.fail(f"MD5 sums of core and core device do not match! "
+    with TestRun.step("Compare crc32 sums for cores and core devices"):
+        for core_crc32, dev_crc32, mode, fs in zip(
+                core_crc32s, dev_crc32s, cache_modes, filesystems
+        ):
+            if core_crc32 != dev_crc32:
+                TestRun.fail("Crc32 sums of core and core device do not match! "
                              f"Cache mode: {mode} Filesystem: {fs}")
 
 
@@ -129,30 +173,46 @@ def test_data_integrity_5d_dss(filesystems):
 @pytest.mark.require_disk("core4", DiskTypeLowerThan("cache"))
 def test_data_integrity_5d():
     """
-        title: |
-          Data integrity test on three cas instances with different
-          cache modes with duration time equal to 5 days
-        description: |
-          Create 3 cache instances with different cache modes on caches equal to 50GB
-          and cores equal to 150GB, and run workload with data verification.
-        pass_criteria:
-            - System does not crash.
-            - All operations complete successfully.
-            - Data consistency is preserved.
+    title: Data integrity long test on raw devices.
+    description: |
+        Test running workload with data verification on multiple cache instances with
+        different cache modes.
+    pass_criteria:
+      - System does not crash.
+      - All operations complete successfully.
+      - Data consistency is preserved.
     """
+    cache_modes = [CacheMode.WT, CacheMode.WB, CacheMode.WA, CacheMode.WO]
+    runtime = datetime.timedelta(days=5)
+
     with TestRun.step("Prepare cache and core devices"):
-        cache_devices, core_devices = prepare_devices()
+        cache_device = TestRun.disks['cache']
+        core_devices = [TestRun.disks['core1'],
+                        TestRun.disks['core2'],
+                        TestRun.disks['core3'],
+                        TestRun.disks['core4']]
 
-    with TestRun.step("Run 4 cache instances in different cache modes, add single core to each"):
-        cache_modes = [CacheMode.WT, CacheMode.WB, CacheMode.WA, CacheMode.WO]
-        caches = []
-        cores = []
-        for i in range(4):
-            cache, core = start_instance(cache_devices[i], core_devices[i], cache_modes[i])
-            caches.append(cache)
-            cores.append(core)
+        cache_device.create_partitions([Size(50, Unit.GibiByte)] * len(core_devices))
 
-    with TestRun.step("Run test workloads with verification"):
+        core_partitions = []
+        for core_dev in core_devices:
+            core_dev.create_partitions([Size(150, Unit.GibiByte)])
+            core_partitions.append(core_dev.partitions[0])
+        sync()
+
+    with TestRun.step("Start caches, each in different cache mode"):
+        caches = [
+            casadm.start_cache(cache_device, cache_mode, force=True)
+            for cache_device, cache_mode in zip(cache_device.partitions, cache_modes)
+        ]
+
+    with TestRun.step("Add one core to each cache"):
+        cores = [
+            casadm.add_core(cache, core_dev=core_device)
+            for cache, core_device in zip(caches, core_devices)
+        ]
+
+    with TestRun.step("Prepare fio workload config"):
         fio_run = Fio().create_command()
         fio_run.io_engine(IoEngine.libaio)
         fio_run.direct()
@@ -163,54 +223,28 @@ def test_data_integrity_5d():
         fio_run.run_time(runtime)
         fio_run.read_write(ReadWrite.randrw)
         fio_run.io_depth(128)
-        fio_run.blocksize_range([(start_size, stop_size)])
+        fio_run.blocksize_range(
+            [(Size(512, Unit.Byte).get_value(), Size(128, Unit.KibiByte).get_value())]
+        )
         for core in cores:
             fio_job = fio_run.add_job()
             fio_job.target(core)
-        fio_run.run()
 
-    with TestRun.step("Calculate md5 for each core"):
-        core_md5s = [md5sum(core.path) for core in cores]
+    with TestRun.step("Run test workload with data verification"):
+        fio_run.run(fio_timeout=runtime + datetime.timedelta(hours=2))
+
+    with TestRun.step("Calculate crc32 for each core"):
+        core_crc32s = [crc32sum(core.path, timeout=timedelta(hours=4)) for core in cores]
 
     with TestRun.step("Stop caches"):
         for cache in caches:
             cache.stop()
 
-    with TestRun.step("Calculate md5 for each core"):
-        dev_md5s = [md5sum(dev.full_path) for dev in core_devices]
+    with TestRun.step("Calculate crc32 for each core"):
+        dev_crc32s = [crc32sum(dev.path, timeout=timedelta(hours=4)) for dev in core_devices]
 
-    with TestRun.step("Compare md5 sums for cores and core devices"):
-        for core_md5, dev_md5, mode in zip(core_md5s, dev_md5s, cache_modes):
-            if core_md5 != dev_md5:
-                TestRun.fail(f"MD5 sums of core and core device do not match! "
+    with TestRun.step("Compare crc32 sums for cores and core devices"):
+        for core_crc32, dev_crc32, mode in zip(core_crc32s, dev_crc32s, cache_modes):
+            if core_crc32 != dev_crc32:
+                TestRun.fail("Crc32 sums of core and core device do not match! "
                              f"Cache mode: {mode}")
-
-
-def start_instance(cache_device, core_device, cache_mode):
-    TestRun.LOGGER.info(f"Starting cache with cache mode {cache_mode}")
-    cache = casadm.start_cache(cache_device, cache_mode, force=True)
-    TestRun.LOGGER.info(f"Adding core device to cache device")
-    core = casadm.add_core(cache, core_dev=core_device)
-
-    return cache, core
-
-
-def prepare_devices():
-    cache_device = TestRun.disks['cache']
-    core_devices = [TestRun.disks['core1'],
-                    TestRun.disks['core2'],
-                    TestRun.disks['core3'],
-                    TestRun.disks['core4']]
-
-    cache_device.create_partitions([Size(50, Unit.GibiByte),
-                                    Size(50, Unit.GibiByte),
-                                    Size(50, Unit.GibiByte),
-                                    Size(50, Unit.GibiByte)])
-
-    core_partitions = []
-    for core_dev in core_devices:
-        core_dev.create_partitions([Size(150, Unit.GibiByte)])
-        core_partitions.append(core_dev.partitions[0])
-    sync()
-
-    return cache_device.partitions, core_partitions


### PR DESCRIPTION
Setting fio timeout manually, accordingly to workload runtime.
Getting I/O class file size ranges directly from config and create separate fio jobs per each file size range.
Small refactor to increase readability.