### PR TITLE
Fix acp wakeup tests

### DIFF
--- a/test/functional/tests/lazy_writes/cleaning_policy/test_acp.py
+++ b/test/functional/tests/lazy_writes/cleaning_policy/test_acp.py
@@ -358,6 +358,9 @@ def test_acp_param_wake_up_time(cache_line_size, cache_mode):
                 time.sleep(15)
                 blktrace_output = blktrace.stop_monitoring()
 
+                if len(blktrace_output) == 0:
+                    TestRun.LOGGER.error("blktrace length == 0")
+
                 for (prev, curr) in zip(blktrace_output, blktrace_output[1:]):
                     if not new_acp_iteration(prev, curr):
                         continue

--- a/test/functional/tests/lazy_writes/cleaning_policy/test_acp.py
+++ b/test/functional/tests/lazy_writes/cleaning_policy/test_acp.py
@@ -308,11 +308,16 @@ def test_acp_param_wake_up_time(cache_line_size, cache_mode):
             n=10,
         )
         acp_configs = []
+
+        # Always set flush_max_buffers to 1 so we can accurately determine start
+        # of cleaner iteration
         for config in generated_vals:
             acp_configs.append(
-                FlushParametersAcp(wake_up_time=Time(milliseconds=config))
+                FlushParametersAcp(flush_max_buffers=1, wake_up_time=Time(milliseconds=config))
             )
-        acp_configs.append(FlushParametersAcp.default_acp_params())
+        default = FlushParametersAcp.default_acp_params()
+        default.flush_max_buffers = 1
+        acp_configs.append(default)
 
 
     with TestRun.step("Prepare devices."):

--- a/test/functional/tests/lazy_writes/cleaning_policy/test_acp.py
+++ b/test/functional/tests/lazy_writes/cleaning_policy/test_acp.py
@@ -1,6 +1,6 @@
 #
 # Copyright(c) 2020-2022 Intel Corporation
-# Copyright(c) 2024 Huawei Technologies Co., Ltd.
+# Copyright(c) 2024-2025 Huawei Technologies Co., Ltd.
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
@@ -302,7 +302,7 @@ def test_acp_param_wake_up_time(cache_line_size, cache_mode):
           - ACP flush iterations are triggered with defined frequency.
     """
     with TestRun.step("Test prepare."):
-        error_threshold_ms = 50
+        error_threshold_ms = 200
         generated_vals = get_random_list(
             min_val=FlushParametersAcp.acp_params_range().wake_up_time[0],
             max_val=FlushParametersAcp.acp_params_range().wake_up_time[1],


### PR DESCRIPTION
Fix multiple problems with ACP wake_up_time tests:
* real device introduces variability in results - replace devices with nullblks
* multiple flush buffers allowed lead to false-positives while detecting time of ACP iteration start - limit buffers to one per iteration
* error threshold is set too low