### PR TITLE
Fix kernel module compilation flags

### DIFF
--- a/configure.d/Makefile
+++ b/configure.d/Makefile
@@ -1,5 +1,6 @@
 #
 # Copyright(c) 2012-2022 Intel Corporation
+# Copyright(c) 2025 Huawei Technologies
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
@@ -13,7 +14,7 @@ check_cflag=$(shell echo "" | \
 	if [ $$? -eq 0 ]; then echo 1; else echo 0; fi; )
 
 ifeq ($(call check_cflag,-Werror=int-conversion), 1)
-EXTRA_CFLAGS += -Werror=int-conversion 
+ccflags-y += -Werror=int-conversion
 endif
 KBUILD_CFLAGS += -Wno-error
 all:

--- a/modules/config.mk
+++ b/modules/config.mk
@@ -1,6 +1,6 @@
 #
 # Copyright(c) 2012-2021 Intel Corporation
-# Copyright(c) 2024 Huawei Technologies
+# Copyright(c) 2024-2025 Huawei Technologies
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
@@ -11,16 +11,15 @@ check_cflag=$(shell echo "" | \
 	if [ $$? -eq 0 ]; then echo 1; else echo 0; fi; )
 
 -include $(VERSION_FILE)
-EXTRA_CFLAGS += -DCAS_VERSION_MAIN=$(CAS_VERSION_MAIN)
-EXTRA_CFLAGS += -DCAS_VERSION_MAJOR=$(CAS_VERSION_MAJOR)
-EXTRA_CFLAGS += -DCAS_VERSION_MINOR=$(CAS_VERSION_MINOR)
-EXTRA_CFLAGS += -DCAS_VERSION=\"$(CAS_VERSION)\"
-EXTRA_CFLAGS += -Ofast -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security
-
-EXTRA_CFLAGS += -I$(M)
-EXTRA_CFLAGS += -I$(M)/cas_cache
-EXTRA_CFLAGS += -I$(M)/include
-EXTRA_CFLAGS += -DCAS_KERNEL=\"$(KERNELRELEASE)\"
+ccflags-y += -DCAS_VERSION_MAIN=$(CAS_VERSION_MAIN)
+ccflags-y += -DCAS_VERSION_MAJOR=$(CAS_VERSION_MAJOR)
+ccflags-y += -DCAS_VERSION_MINOR=$(CAS_VERSION_MINOR)
+ccflags-y += -DCAS_VERSION=\"$(CAS_VERSION)\"
+ccflags-y += -Ofast -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security
+ccflags-y += -I$(M)
+ccflags-y += -I$(M)/cas_cache
+ccflags-y += -I$(M)/include
+ccflags-y += -DCAS_KERNEL=\"$(KERNELRELEASE)\"
 
 check_header=$(shell echo "\#include <${1}>" | \
 	gcc -c -xc -o /dev/null - 2>/dev/null; \
@@ -31,9 +30,9 @@ INCDIR = $(PWD)/include
 KERNEL_VERSION = $(shell echo $(KERNELRELEASE) | cut -d'.' -f1)
 KERNEL_MAJOR = $(shell echo $(KERNELRELEASE) | cut -d'.' -f2)
 
-EXTRA_CFLAGS += -Werror
+ccflags-y += -Werror
 
-EXTRA_LDFLAGS += -z noexecstack -z relro -z now
+ldflags-y += -z noexecstack -z relro -z now
 
 # workaround for missing objtool in kernel devel package
 ifeq ($(shell expr $(KERNEL_VERSION) == 4 \& $(KERNEL_MAJOR) == 14),1)

--- a/modules/extra.mk
+++ b/modules/extra.mk
@@ -1,11 +1,12 @@
 #
 # Copyright(c) 2012-2021 Intel Corporation
+# Copyright(c) 2025 Huawei Technologies
 # SPDX-License-Identifier: BSD-3-Clause
 #
 ifneq ($(M),)
 
 ifeq ($(CAS_EXT_EXP),1)
-EXTRA_CFLAGS += -DWI_AVAILABLE
+ccflags-y += -DWI_AVAILABLE
 endif
 
 else #KERNELRELEASE


### PR DESCRIPTION
Replace deprecated EXTRA_*FLAGS with *flags-y in kernel module build environment due to removal of old flags in kernel 6.15.