### PR TITLE
pckgen: Improve RPM building

### DIFF
--- a/tools/pckgen.d/rpm/CAS_NAME.spec
+++ b/tools/pckgen.d/rpm/CAS_NAME.spec
@@ -37,10 +37,10 @@ BuildRequires: gcc
 BuildRequires: make
 BuildRequires: procps
 BuildRequires: python3
-BuildRequires: kernel = %{kver_pkg}
-BuildRequires: kernel-devel = %{kver_pkg}
 # Allow using different version of kernel-headers package (some distros requires it).
 BuildRequires: kernel-headers
+BuildRequires: <KERNEL_PKG> = %{kver_pkg}
+BuildRequires: <KERNEL_DEVEL_PKG> = %{kver_pkg}
 BuildRequires: <LIBELF_PKG>
 BuildRequires: <UTIL_PKG>
 Requires:      <CAS_NAME>-modules-%{version}


### PR DESCRIPTION
- fix building on SUSE in mock environment
- always allow specifying a partial kernel version and install the newest one matching
- improve kernel version check
- add option to list available kernels