### PR TITLE
casadm: Fix compiler warning

### DIFF
--- a/casadm/cas_lib.c
+++ b/casadm/cas_lib.c
@@ -322,7 +322,7 @@ static int validate_str_val_mapping_multi(const char* s,
 {
 	const char* p;
 	char* token;
-	char* delim;
+	const char* delim;
 	int value = 0;
 	int token_val;
 


### PR DESCRIPTION
cas_lib.c:335:23: error: assignment discards ‘const’ qualifier from pointer target type [-Werror=discarded-qualifiers]
  335 |                 delim = strchr(p, ',');
      |                       ^