### PR TITLE
Replace core_id array with a bitmap in kcas_cache_info

### DIFF
--- a/casadm/cas_lib.c
+++ b/casadm/cas_lib.c
@@ -790,7 +790,8 @@ error_out:
  */
 struct cache_device *get_cache_device(const struct kcas_cache_info *info, bool by_id_path)
 {
-	int core_id, cache_id, ret;
+	unsigned int core_id;
+	int cache_id, ret;
 	struct cache_device *cache;
 	struct core_device core;
 	cache_id = info->cache_id;
@@ -824,9 +825,11 @@ struct cache_device *get_cache_device(const struct kcas_cache_info *info, bool b
 	cache->promotion_policy = info->info.promotion_policy;
 	cache->size = info->info.cache_line_size;
 
-	for (cache->core_count = 0; cache->core_count < info->info.core_count; ++cache->core_count) {
-		core_id = info->core_id[cache->core_count];
-
+	cache->core_count = 0;
+	for (core_id = 0; cache->core_count < info->info.core_count; core_id++) {
+		core_id = core_id_bitmap_next(info->core_id_bitmap, core_id);
+		if (core_id == OCF_CORE_NUM)
+			break;
 		ret = get_core_device(cache_id, core_id, &core, by_id_path);
 		if (0 != ret) {
 			break;
@@ -834,6 +837,7 @@ struct cache_device *get_cache_device(const struct kcas_cache_info *info, bool b
 			memcpy_s(&cache->cores[cache->core_count],
 				sizeof(cache->cores[cache->core_count]),
 				&core, sizeof(core));
+			++cache->core_count;
 		}
 	}
 

--- a/casadm/cas_lib.h
+++ b/casadm/cas_lib.h
@@ -26,6 +26,32 @@
 
 #define ARRAY_SIZE(array) (sizeof(array) / sizeof((array)[0]))
 
+static inline bool core_id_bitmap_test(const uint64_t *bitmap, unsigned int id)
+{
+	return (bitmap[id / 64] >> (id % 64)) & 1;
+}
+
+/* Returns the next set bit at position >= start, or OCF_CORE_NUM if none.
+ * Skips empty 64-bit words to stay O(set bits), not O(OCF_CORE_NUM). */
+static inline unsigned int core_id_bitmap_next(const uint64_t *bitmap,
+		unsigned int start)
+{
+	unsigned int n_words = DIV_ROUND_UP_STATIC(OCF_CORE_NUM, 64);
+	unsigned int word_idx = start / 64;
+	uint64_t w;
+
+	if (word_idx >= n_words)
+		return OCF_CORE_NUM;
+
+	w = bitmap[word_idx] & (~(uint64_t)0 << (start % 64));
+	while (!w) {
+		if (++word_idx >= n_words)
+			return OCF_CORE_NUM;
+		w = bitmap[word_idx];
+	}
+	return word_idx * 64 + __builtin_ctzll(w);
+}
+
 #define FAILURE 1		/**< default non-zero exit code. */
 #define INTERRUPTED 2		/**< if command is interrupted */
 #define SUCCESS 0		/**< 0 exit code from majority of our functions \

--- a/casadm/statistics_model.c
+++ b/casadm/statistics_model.c
@@ -776,7 +776,7 @@ void *stats_printout(void *ctx)
 int cache_status(unsigned int cache_id, unsigned int core_id, int io_class_id,
 		 unsigned int stats_filters, unsigned int output_format, bool by_id_path)
 {
-	int ctrl_fd, i;
+	int ctrl_fd;
 	int ret = SUCCESS;
 	struct kcas_cache_info cache_info;
 
@@ -831,12 +831,7 @@ int cache_status(unsigned int cache_id, unsigned int core_id, int io_class_id,
 
 	/* Check if core exists in cache */
 	if (core_id != OCF_CORE_ID_INVALID) {
-		for (i = 0; i < cache_info.info.core_count; ++i) {
-			if (core_id == cache_info.core_id[i]) {
-				break;
-			}
-		}
-		if (i == cache_info.info.core_count) {
+		if (!core_id_bitmap_test(cache_info.core_id_bitmap, core_id)) {
 			cas_printf(LOG_ERR, "No such core device in cache.\n");
 			ret = FAILURE;
 			goto cleanup;

--- a/modules/cas_cache/layer_cache_management.c
+++ b/modules/cas_cache/layer_cache_management.c
@@ -3552,12 +3552,13 @@ int cache_mngt_get_info(struct kcas_cache_info *info)
 	}
 
 	/* Collect cores IDs */
+	memset(info->core_id_bitmap, 0, sizeof(info->core_id_bitmap));
 	for (i = 0, j = 0; j < info->info.core_count &&
 			i < OCF_CORE_NUM; i++) {
 		if (get_core_by_id(cache, i, &core))
 			continue;
 
-		info->core_id[j] = i;
+		set_bit(i, (unsigned long *)info->core_id_bitmap);
 		j++;
 	}
 

--- a/modules/include/cas_ioctl_codes.h
+++ b/modules/include/cas_ioctl_codes.h
@@ -21,6 +21,8 @@
 #include <linux/limits.h>
 #include <linux/ioctl.h>
 
+#define DIV_ROUND_UP_STATIC(n, d) (((n) + (d) - 1) / (d))
+
 /**
  * Max path, string size
  */
@@ -178,9 +180,10 @@ struct kcas_cache_info {
 	char cache_path_name[MAX_STR_LEN];
 
 	/**
-	 * IDs of cores associated with this cache.
+	 * Bitmap of core IDs associated with this cache
 	 */
-	uint16_t core_id[OCF_CORE_NUM];
+	uint64_t core_id_bitmap[DIV_ROUND_UP_STATIC(OCF_CORE_NUM,
+			8 * sizeof(uint64_t))];
 
 	struct ocf_cache_info info;
 


### PR DESCRIPTION
Reduce the struct size from 12288 bytes to 4608 bytes, to fix compilation on PowerPC architecture, where _IOC_SIZEBITS is set to 13, limiting maximum size of ioctl argument structure to under 8192 bytes.