### PR TITLE
README: Remove stale status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Open CAS Linux
 
 [![Build Status](https://github.com/Open-CAS/open-cas-linux/actions/workflows/build-master.yml/badge.svg)](https://github.com/Open-CAS/open-cas-linux/actions/workflows/build-master.yml)
-[![Tests Status](https://d1rxsi9lvcwnz5.cloudfront.net/master-status/ocl/tests/curr-badge.svg)](https://d1rxsi9lvcwnz5.cloudfront.net/master-status/ocl/tests/tests.html)
-[![Coverity status](https://scan.coverity.com/projects/19084/badge.svg)](https://scan.coverity.com/projects/open-cas-open-cas-linux)
 [![License](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg)](LICENSE)
 
 Open CAS  accelerates Linux applications by caching active (hot) data to


### PR DESCRIPTION
The AWS-based CI runners are long gone. The CI runs on GH Actions. Clean up the old status badges.