### PR TITLE
Change install patch from /sbin to /usr/sbin

### DIFF
--- a/casadm/Makefile
+++ b/casadm/Makefile
@@ -9,7 +9,7 @@ include ../tools/helpers.mk
 PWD:=$(shell pwd)
 MODULESDIR:=$(PWD)/../modules
 METADATA_DIR:=$(PWD)/../.metadata
-BINARY_PATH = /sbin
+BINARY_PATH = /usr/sbin
 
 VERSION_FILE := $(METADATA_DIR)/cas_version
 

--- a/tools/pckgen.d/deb/debian/CAS_NAME.install
+++ b/tools/pckgen.d/deb/debian/CAS_NAME.install
@@ -1,7 +1,7 @@
 etc/
 usr/lib/opencas/
 usr/lib/udev/
-sbin/
+usr/sbin/
 var/
 utils/open-cas.shutdown usr/lib/systemd/system-shutdown/
 utils/open-cas.service usr/lib/systemd/system/

--- a/tools/pckgen.d/rpm/CAS_NAME.spec
+++ b/tools/pckgen.d/rpm/CAS_NAME.spec
@@ -162,8 +162,8 @@ fi
 /usr/lib/opencas/opencas.py
 /usr/lib/udev/rules.d/60-persistent-storage-cas-load.rules
 /usr/lib/udev/rules.d/60-persistent-storage-cas.rules
-/sbin/casadm
-/sbin/casctl
+/usr/sbin/casadm
+/usr/sbin/casctl
 /usr/bin/opencas_exporter
 /usr/lib/systemd/system-shutdown/open-cas.shutdown
 /usr/lib/systemd/system/open-cas-shutdown.service

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -58,8 +58,8 @@ install_files:
 
 	@install -m 644 -D etc/dracut.conf.d/opencas.conf $(DESTDIR)/etc/dracut.conf.d/opencas.conf
 
-	@install -m 755 -d $(DESTDIR)/sbin
-	@ln -fs $(CASCTL_DIR)/casctl $(DESTDIR)/sbin/casctl
+	@install -m 755 -d $(DESTDIR)/usr/sbin
+	@ln -fs $(CASCTL_DIR)/casctl $(DESTDIR)/usr/sbin/casctl
 
 	@install -m 644 -D 60-persistent-storage-cas-load.rules $(DESTDIR)$(UDEVRULES_DIR)/60-persistent-storage-cas-load.rules
 	@install -m 644 -D 60-persistent-storage-cas.rules $(DESTDIR)$(UDEVRULES_DIR)/60-persistent-storage-cas.rules
@@ -88,7 +88,7 @@ uninstall:
 
 	$(call remove-file,$(DESTDIR)/etc/dracut.conf.d/opencas.conf)
 
-	$(call remove-file,$(DESTDIR)/sbin/casctl)
+	$(call remove-file,$(DESTDIR)/usr/sbin/casctl)
 
 	$(call remove-file,$(DESTDIR)/usr/share/man/man8/casctl.8.gz)
 


### PR DESCRIPTION
Most modern distros already switched to usrmerge. It's safer and follows the current best practices to use /usr/sbin.