### PR TITLE
fix(dkms): run ./configure on the correct kernel headers

### DIFF
--- a/configure
+++ b/configure
@@ -110,6 +110,9 @@ fi
 
 if [ ! -f /usr/include/libelf.h ]; then
 	KERNEL_CONFIG="$KERNEL_DIR/.config"
+	if [ ! -f "$KERNEL_CONFIG" ]; then
+		KERNEL_CONFIG="$KERNEL_DIR/include/config/auto.conf"
+	fi
 	if [ -f "$KERNEL_CONFIG" ]; then
 		if grep ^CONFIG_UNWINDER_ORC=[Yy] "$KERNEL_CONFIG" &>/dev/null; then
 			echo "Error: CONFIG_UNWINDER_ORC=y option is set in your kernel,"\

--- a/configure
+++ b/configure
@@ -146,6 +146,11 @@ FILES_COUNT=`echo $CONFIG_FILES | wc -w`
 
 CONFIG_FILE=$SCRIPTPATH/"config.out"
 
+# Name under which the probed kernel is stored in the config file, so that a
+# header generated from a saved config still states which kernel API it
+# describes - see generate_header() and modules/Makefile.
+KERNEL_DIR_TAG="CONFIGURED_KERNEL_DIR"
+
 generate_config() {
 	rm -f ${CONFIG_FILE}
 	touch ${CONFIG_FILE}
@@ -175,6 +180,8 @@ generate_config() {
 		grep "X" ${CONFIG_FILE} | cut -f1 -d ' '
 		exit 1
 	fi
+
+	echo "$KERNEL_DIR_TAG $(realpath "$KERNEL_DIR")" >> ${CONFIG_FILE}
 }
 
 generate_header() {
@@ -185,6 +192,12 @@ generate_header() {
 
 	echo "#ifndef __GENERATED_DEFINES_H__" >> $SCRIPTPATH/modules/generated_defines.h
 	echo "#define __GENERATED_DEFINES_H__" >> $SCRIPTPATH/modules/generated_defines.h
+
+	CONFIGURED_KERNEL_DIR=$(grep "^$KERNEL_DIR_TAG " ${CONFIG_FILE} | cut -d' ' -f2-)
+	if [ -n "$CONFIGURED_KERNEL_DIR" ]; then
+		echo "#define CAS_CONFIGURED_KERNEL_DIR \"$CONFIGURED_KERNEL_DIR\"" \
+			>> $SCRIPTPATH/modules/generated_defines.h
+	fi
 
 	echo "Configuring OpenCAS"
 	for file in $FIRST; do

--- a/configure
+++ b/configure
@@ -7,6 +7,57 @@
 
 MISSING_TOOLS=0
 
+usage() {
+	cat <<-EOF
+	Usage: $0 [options] [config-file]
+
+	Probes the kernel the modules will be built against and generates
+	modules/generated_defines.h accordingly.
+
+	Options:
+	  --kernel-dir DIR        use the kernel headers in DIR, e.g.
+	                          /lib/modules/VERSION/build
+	                          (default: the running kernel's)
+	  -h, --help              print this message
+
+	If config-file is given, the kernel is not probed at all and the
+	configuration stored in that file is applied as is.
+
+	Whatever kernel is selected here must be the same one 'make' is later
+	pointed at, otherwise the generated header describes a different kernel
+	API than the one the modules are compiled against.
+	EOF
+}
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+	--kernel-dir)
+		if [ -z "$2" ]; then
+			echo >&2 "Error: '$1' requires an argument"
+			usage >&2
+			exit 1
+		fi
+		KERNEL_DIR_ARG="$2"
+		shift 2 ;;
+	-h|--help)
+		usage
+		exit 0 ;;
+	-*)
+		echo >&2 "Error: unknown option '$1'"
+		usage >&2
+		exit 1 ;;
+	*)
+		CONFIG_FILE_ARG="$1"
+		shift ;;
+	esac
+done
+
+# Assigned outright rather than defaulted from the environment: honouring
+# $KERNEL_DIR as well would leave two ways of saying the same thing, with no
+# way to tell which one was meant when they disagree.
+KERNEL_DIR="${KERNEL_DIR_ARG:-/lib/modules/$(uname -r)/build}"
+export KERNEL_DIR
+
 check_util() {
 	which $1 &> /dev/null
 	if [ $? -ne 0 ]
@@ -44,9 +95,9 @@ if [ "$SUBMODULES_MISSING" ]; then
 	MISSING_TOOLS=1
 fi
 
-if [ ! -e /lib/modules/$(uname -r)/build/ &> /dev/null ] && [ "$KERNEL_DIR" == "" ]
+if [ ! -d "$KERNEL_DIR" ]
 then
-	echo >&2 "Error: missing kernel headers and/or kernel devel"
+	echo >&2 "Error: missing kernel headers and/or kernel devel in '$KERNEL_DIR'"
 	MISSING_TOOLS=1
 fi
 
@@ -58,7 +109,7 @@ then
 fi
 
 if [ ! -f /usr/include/libelf.h ]; then
-	KERNEL_CONFIG=$(find /usr/src/ -type d -name "*$(uname -r)")/.config
+	KERNEL_CONFIG="$KERNEL_DIR/.config"
 	if [ -f "$KERNEL_CONFIG" ]; then
 		if grep ^CONFIG_UNWINDER_ORC=[Yy] "$KERNEL_CONFIG" &>/dev/null; then
 			echo "Error: CONFIG_UNWINDER_ORC=y option is set in your kernel,"\
@@ -98,7 +149,7 @@ generate_config() {
 	n_cores=$(nproc)
 
 	# Compile each test module in background
-	echo "Preparing configuration"
+	echo "Preparing configuration for kernel headers in $KERNEL_DIR"
 		for file in $CONFIG_FILES; do
 			# $1 - Action to be performed
 			# $2 - File with stored configuration
@@ -146,10 +197,10 @@ generate_header() {
 	echo "#endif /* __GENERATED_DEFINES_H__ */" >> $SCRIPTPATH/modules/generated_defines.h
 }
 
-if [ -z "$1" ]; then
+if [ -z "$CONFIG_FILE_ARG" ]; then
 	generate_config
 else
-	CONFIG_FILE=$(realpath $1)
+	CONFIG_FILE=$(realpath $CONFIG_FILE_ARG)
 	if [ $? -ne 0 ] ; then
 		echo "Invaild path to config file!"
 		exit 1

--- a/modules/Makefile
+++ b/modules/Makefile
@@ -46,8 +46,22 @@ else
 sync distsync:
 endif
 
-default: sync
+default: sync check_configured_kernel
 	cd $(KERNEL_DIR) && $(MAKE) M=$(PWD) modules
+
+# generated_defines.h describes the kernel API './configure' probed. Compiling
+# it against another kernel produces code for an API that kernel may not have,
+# so say so up front instead of failing with a wall of compiler errors.
+check_configured_kernel:
+	@configured=$$(sed -n 's/^#define CAS_CONFIGURED_KERNEL_DIR "\(.*\)"$$/\1/p' \
+		$(PWD)/generated_defines.h 2>/dev/null); \
+	building=$$(realpath $(KERNEL_DIR)); \
+	if [ -n "$$configured" ] && [ "$$configured" != "$$building" ]; then \
+		echo "ERROR: './configure' was run for the kernel in $$configured," >&2; \
+		echo "but the modules are being built against $$building." >&2; \
+		echo "Re-run './configure --kernel-dir $$building' first." >&2; \
+		exit 1; \
+	fi
 
 clean:
 	cd $(KERNEL_DIR) && make M=$(PWD) clean
@@ -80,6 +94,6 @@ uninstall:
 
 reinstall: uninstall install
 
-.PHONY: all default clean distclean sync distsync install uninstall
+.PHONY: all default check_configured_kernel clean distclean sync distsync install uninstall
 
 endif

--- a/tools/pckgen.d/deb/debian/CAS_NAME-modules.dkms
+++ b/tools/pckgen.d/deb/debian/CAS_NAME-modules.dkms
@@ -6,6 +6,10 @@ DEST_MODULE_LOCATION[0]="/<CAS_MODULES_DIR>"
 BUILT_MODULE_NAME[1]="cas_bd"
 BUILT_MODULE_LOCATION[1]="modules/cas_bd/"
 DEST_MODULE_LOCATION[1]="/<CAS_MODULES_DIR>"
-PRE_BUILD="./configure"
-MAKE[0]="make -j -C modules/ KERNEL_VERSION=$kernelver"
+# DKMS builds for a kernel that is not necessarily the running one, so the
+# kernel has to be spelled out for './configure' as well - left to itself it
+# probes the running kernel and generates a header for the wrong kernel API.
+DKMS_KERNEL_DIR="/lib/modules/$kernelver/build"
+PRE_BUILD="./configure --kernel-dir $DKMS_KERNEL_DIR"
+MAKE[0]="make -j -C modules/ KERNEL_VERSION=$kernelver KERNEL_DIR=$DKMS_KERNEL_DIR"
 AUTOINSTALL=yes

--- a/tools/pckgen.d/rpm/CAS_NAME.spec
+++ b/tools/pckgen.d/rpm/CAS_NAME.spec
@@ -76,7 +76,7 @@ This package contains only CAS kernel modules.
 
 %build
 export KERNEL_DIR=/lib/modules/%{kver}/build/
-./configure
+./configure --kernel-dir $KERNEL_DIR
 <MAKE_BUILD>
 
 


### PR DESCRIPTION
Fixes #1772 

This was written by Claude Opus, so it's a little aggressive in preventing the issue from occurring, as coding agents tend to be defensive at paranoid levels. I figured I'd leave it all here in case any of it is desirable for the team.

Please feel free to leave feedback then I'll clean up/update the PR manually.