### PR TITLE
[v26.03.4] Handle flush status properly

### DIFF
--- a/modules/cas_cache/layer_cache_management.c
+++ b/modules/cas_cache/layer_cache_management.c
@@ -3287,6 +3287,7 @@ int cache_mngt_exit_instance(const char *cache_name, size_t name_len, int flush)
 			flush_status = -ENODEV;
 		}
 	}
+	context->flush_status = flush_status;
 
 	if (flush && !flush_status)
 		BUG_ON(ocf_mngt_cache_is_dirty(cache));


### PR DESCRIPTION
context->flush_status is used in exit_instance_finish() to determine the effectve error code. Needs to be set after flushing the cache.