### PR TITLE
Check if exp_obj exist before accesing the priv

### DIFF
--- a/modules/cas_cache/layer_cache_management.c
+++ b/modules/cas_cache/layer_cache_management.c
@@ -3444,8 +3444,7 @@ static int _cache_mngt_capture_exp_objs(ocf_cache_t cache,
 	int n = 0;
 
 	ocf_core_for_each(core, cache, true) {
-		priv_top = cas_get_priv_top(core);
-		if (priv_top->expobj_valid)
+		if (cas_core_exp_obj_exists(core))
 			n++;
 	}
 
@@ -3460,9 +3459,11 @@ static int _cache_mngt_capture_exp_objs(ocf_cache_t cache,
 
 	n = 0;
 	ocf_core_for_each(core, cache, true) {
+		if (!cas_core_exp_obj_exists(core))
+			continue;
+
 		priv_top = cas_get_priv_top(core);
-		if (priv_top->expobj_valid)
-			list->exp_objs[n++] = priv_top->exp_obj;
+		list->exp_objs[n++] = priv_top->exp_obj;
 	}
 
 	return 0;
@@ -3481,9 +3482,10 @@ static void _cache_mngt_freeze_exp_objs(ocf_cache_t cache)
 	struct cas_priv_top *priv_top;
 
 	ocf_core_for_each(core, cache, true) {
-		priv_top = cas_get_priv_top(core);
-		if (!priv_top->expobj_valid)
+		if (!cas_core_exp_obj_exists(core))
 			continue;
+
+		priv_top = cas_get_priv_top(core);
 		cas_exp_obj_freeze_queue(priv_top->exp_obj);
 	}
 }
@@ -3494,9 +3496,10 @@ static void _cache_mngt_unfreeze_exp_objs(ocf_cache_t cache)
 	struct cas_priv_top *priv_top;
 
 	ocf_core_for_each(core, cache, true) {
-		priv_top = cas_get_priv_top(core);
-		if (!priv_top->expobj_valid)
+		if (!cas_core_exp_obj_exists(core))
 			continue;
+
+		priv_top = cas_get_priv_top(core);
 		cas_exp_obj_unfreeze_queue(priv_top->exp_obj);
 	}
 }
@@ -3515,9 +3518,10 @@ static void _cache_mngt_set_exp_objs_pt(ocf_cache_t cache)
 	struct cas_priv_top *priv_top;
 
 	ocf_core_for_each(core, cache, true) {
-		priv_top = cas_get_priv_top(core);
-		if (!priv_top->expobj_valid)
+		if (!cas_core_exp_obj_exists(core))
 			continue;
+
+		priv_top = cas_get_priv_top(core);
 		cas_exp_obj_set_passthrough(priv_top->exp_obj, true);
 	}
 }
@@ -3528,9 +3532,10 @@ static void _cache_mngt_clear_exp_objs_pt(ocf_cache_t cache)
 	struct cas_priv_top *priv_top;
 
 	ocf_core_for_each(core, cache, true) {
-		priv_top = cas_get_priv_top(core);
-		if (!priv_top->expobj_valid)
+		if (!cas_core_exp_obj_exists(core))
 			continue;
+
+		priv_top = cas_get_priv_top(core);
 		cas_exp_obj_set_passthrough(priv_top->exp_obj, false);
 	}
 }
@@ -4077,7 +4082,6 @@ int cache_mngt_get_core_info(struct kcas_core_info *info)
 	ocf_cache_t cache;
 	ocf_core_t core;
 	const struct ocf_volume_uuid *uuid;
-	struct cas_priv_top *priv_top;
 	int result;
 
 	result = mngt_get_cache_by_id(cas_ctx, info->cache_id, &cache);
@@ -4106,9 +4110,7 @@ int cache_mngt_get_core_info(struct kcas_core_info *info)
 	}
 
 	info->state = ocf_core_get_state(core);
-
-	priv_top = cas_get_priv_top(core);
-	info->exp_obj_exists = priv_top->expobj_valid;
+	info->exp_obj_exists = cas_core_exp_obj_exists(core);
 
 unlock:
 	ocf_mngt_cache_read_unlock(cache);

--- a/modules/cas_cache/service_ui_netlink.c
+++ b/modules/cas_cache/service_ui_netlink.c
@@ -89,7 +89,6 @@ static void cas_nl_collect_core(ocf_cache_t cache, uint16_t core_id,
 		ocf_core_t core, struct cas_nl_core_dump *dst)
 {
 	const struct ocf_volume_uuid *uuid;
-	struct cas_priv_top *priv_top;
 	ocf_seq_cutoff_policy policy;
 
 	dst->id = core_id;
@@ -99,9 +98,7 @@ static void cas_nl_collect_core(ocf_cache_t cache, uint16_t core_id,
 
 	ocf_core_get_info(core, &dst->info);
 	dst->state = ocf_core_get_state(core);
-
-	priv_top = cas_get_priv_top(core);
-	dst->exp_obj_exists = priv_top->expobj_valid;
+	dst->exp_obj_exists = cas_core_exp_obj_exists(core);
 
 	ocf_stats_collect_core(core, &dst->usage, &dst->req,
 			&dst->blocks, &dst->errors);

--- a/modules/cas_cache/volume/vol_block_dev_top.c
+++ b/modules/cas_cache/volume/vol_block_dev_top.c
@@ -656,8 +656,13 @@ int kcas_core_create_exported_object(ocf_core_t core)
 
 int kcas_core_destroy_exported_object(ocf_core_t core)
 {
-	struct cas_priv_top *priv_top = cas_get_priv_top(core);
+	struct cas_priv_top *priv_top;
 	int result;
+
+	if (!cas_core_exp_obj_exists(core))
+		return 0;
+
+	priv_top = cas_get_priv_top(core);
 
 	result = kcas_volume_destroy_exported_object(priv_top);
 	if (result)
@@ -671,7 +676,12 @@ int kcas_core_destroy_exported_object(ocf_core_t core)
 
 int kcas_core_deposit_exported_object(ocf_core_t core)
 {
-	struct cas_priv_top *priv_top = cas_get_priv_top(core);
+	struct cas_priv_top *priv_top;
+
+	if (!cas_core_exp_obj_exists(core))
+		return 0;
+
+	priv_top = cas_get_priv_top(core);
 
 	cas_exp_obj_box_deposit(priv_top->exp_obj);
 
@@ -744,10 +754,10 @@ int kcas_cache_destroy_all_core_exported_objects(ocf_cache_t cache)
 
 	/* Try lock exported objects */
 	ocf_core_for_each(core, cache, true) {
-		priv_top = cas_get_priv_top(core);
-
-		if (!priv_top->expobj_valid)
+		if (!cas_core_exp_obj_exists(core))
 			continue;
+
+		priv_top = cas_get_priv_top(core);
 
 		result = cas_exp_obj_lock(priv_top->exp_obj);
 		if (-EBUSY == result) {
@@ -770,6 +780,9 @@ int kcas_cache_destroy_all_core_exported_objects(ocf_cache_t cache)
 	if (result) {
 		/* Failure, unlock already locked exported objects */
 		ocf_core_for_each(core, cache, true) {
+			if (!cas_core_exp_obj_exists(core))
+				continue;
+
 			priv_top = cas_get_priv_top(core);
 			if (priv_top->expobj_locked) {
 				cas_exp_obj_unlock(priv_top->exp_obj);
@@ -780,16 +793,18 @@ int kcas_cache_destroy_all_core_exported_objects(ocf_cache_t cache)
 	}
 
 	ocf_core_for_each(core, cache, true) {
-		priv_top = cas_get_priv_top(core);
-		if (priv_top->expobj_valid) {
-			printk(KERN_INFO "Stopping device %s\n",
-				_get_disk_name(priv_top->exp_obj));
+		if (!cas_core_exp_obj_exists(core))
+			continue;
 
-			result = cas_exp_obj_dismantle(priv_top->exp_obj);
-			if (!result) {
-				priv_top->expobj_valid = false;
-				destroy_workqueue(priv_top->expobj_wq);
-			}
+		priv_top = cas_get_priv_top(core);
+
+		printk(KERN_INFO "Stopping device %s\n",
+			_get_disk_name(priv_top->exp_obj));
+
+		result = cas_exp_obj_dismantle(priv_top->exp_obj);
+		if (!result) {
+			priv_top->expobj_valid = false;
+			destroy_workqueue(priv_top->expobj_wq);
 		}
 
 		if (priv_top->expobj_locked) {
@@ -800,6 +815,9 @@ int kcas_cache_destroy_all_core_exported_objects(ocf_cache_t cache)
 
 	ocf_core_for_each(core, cache, true) {
 		priv_top = cas_get_priv_top(core);
+		if (!priv_top)
+			continue;
+
 		cas_exp_obj_destroy(priv_top->exp_obj);
 	}
 

--- a/modules/cas_cache/volume/vol_block_dev_top.h
+++ b/modules/cas_cache/volume/vol_block_dev_top.h
@@ -33,6 +33,13 @@ static inline struct cas_priv_top *cas_get_priv_top(ocf_core_t core)
 	return ocf_core_get_priv(core);
 }
 
+static inline bool cas_core_exp_obj_exists(ocf_core_t core)
+{
+	struct cas_priv_top *priv_top = cas_get_priv_top(core);
+
+	return priv_top ? priv_top->expobj_valid : false;
+}
+
 int kcas_core_create_exported_object(ocf_core_t core);
 int kcas_core_destroy_exported_object(ocf_core_t core);
 int kcas_core_deposit_exported_object(ocf_core_t core);


### PR DESCRIPTION
Now the priv_top is freed when exp_obj is destroyed or deposited, so we need to check properly for exp_obj existence before accesing it.

This fixes all the error paths, where the exported object has been aready destroyed, but removing core from the OCF failed, leaving half-deinitialized, so that user can safely retry the failed operation and clean up this broken state.