### PR TITLE
ci: Select limited subset of ruff rules

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,6 +1,11 @@
 line-length = 100
 
 [lint]
+# TODO This is temporary workaround. Ruff 0.16 introduced a ton of new rules, which our code
+# does not follow. To avoid a long list of errors that everyone ignores anyway, select only
+# the rules that were present in the previous version. That way we still effectively enforce
+# following those rules, while giving ourselves some time to gradually expand the rules list.
+select = ["E4", "E7", "E9", "F"]
 ignore = [
     "E402", # All module level imports should be at the top of the file. This means that there
             # should be no statements in between module level imports


### PR DESCRIPTION
Ruff 0.16 introduced many new rules that cause a long list of errors on the existing code, making it completely impossible to check on every single PR. Limit the rules to the list that was present in the previous version to have checks on the rules we already followed and prevent regression.