### PR TITLE
cas_bd: Fix error code handling

### DIFF
--- a/modules/cas_bd/exp_obj.c
+++ b/modules/cas_bd/exp_obj.c
@@ -317,11 +317,11 @@ static const struct attribute_group device_attr_group = {
 	.name = "device",
 };
 
-struct cas_exp_obj *cas_exp_obj_create(struct cas_disk *dsk,
+int cas_exp_obj_create(struct cas_exp_obj **exp_obj, struct cas_disk *dsk,
 		const char *dev_name, struct module *owner,
 		struct cas_exp_obj_ops *ops, void *priv)
 {
-	struct cas_exp_obj *exp_obj;
+	struct cas_exp_obj *tmp_exp_obj;
 	struct request_queue *queue;
 	struct gendisk *gd;
 	cas_queue_limits_t queue_limits;
@@ -332,7 +332,7 @@ struct cas_exp_obj *cas_exp_obj_create(struct cas_disk *dsk,
 	BUG_ON(!ops);
 
 	if (strlen(dev_name) >= DISK_NAME_LEN)
-		return ERR_PTR(-EINVAL);
+		return -EINVAL;
 
 	result = _cas_exp_obj_check_path(dev_name);
 	if (result == -EEXIST) {
@@ -341,23 +341,23 @@ struct cas_exp_obj *cas_exp_obj_create(struct cas_disk *dsk,
 	}
 
 	if (result)
-		return ERR_PTR(result);
+		return result;
 
-	exp_obj = cas_exp_obj_alloc();
-	if (!exp_obj)
-		return ERR_PTR(-ENOMEM);
+	tmp_exp_obj = cas_exp_obj_alloc();
+	if (!tmp_exp_obj)
+		return -ENOMEM;
 
 	cas_disk_get(dsk);
-	exp_obj->dsk = dsk;
+	tmp_exp_obj->dsk = dsk;
 
 	result = cas_disk_hide_parts(dsk);
 	if (result)
 		goto error_hide_parts;
 
-	mutex_init(&exp_obj->openers_lock);
+	mutex_init(&tmp_exp_obj->openers_lock);
 
-	exp_obj->dev_name = kstrdup(dev_name, GFP_KERNEL);
-	if (!exp_obj->dev_name) {
+	tmp_exp_obj->dev_name = kstrdup(dev_name, GFP_KERNEL);
+	if (!tmp_exp_obj->dev_name) {
 		result = -ENOMEM;
 		goto error_kstrdup;
 	}
@@ -366,48 +366,49 @@ struct cas_exp_obj *cas_exp_obj_create(struct cas_disk *dsk,
 		result = -ENAVAIL;
 		goto error_module_get;
 	}
-	exp_obj->owner = owner;
-	exp_obj->ops = ops;
-	exp_obj->private = priv;
-	exp_obj->submit_bio = _cas_exp_obj_submit_bio_default;
+	tmp_exp_obj->owner = owner;
+	tmp_exp_obj->ops = ops;
+	tmp_exp_obj->private = priv;
+	tmp_exp_obj->submit_bio = _cas_exp_obj_submit_bio_default;
 
-	result = _cas_init_tag_set(exp_obj);
+	result = _cas_init_tag_set(tmp_exp_obj);
 	if (result) {
 		goto error_init_tag_set;
 	}
 
-	if (exp_obj->ops->set_queue_limits) {
-		result = exp_obj->ops->set_queue_limits(exp_obj, &queue_limits);
+	if (tmp_exp_obj->ops->set_queue_limits) {
+		result = tmp_exp_obj->ops->set_queue_limits(tmp_exp_obj,
+				&queue_limits);
 		if (result)
 			goto error_set_queue_limits;
 	}
 
-	result = cas_alloc_disk(&gd, &queue, &exp_obj->tag_set,
+	result = cas_alloc_disk(&gd, &queue, &tmp_exp_obj->tag_set,
 			&queue_limits);
 	if (result) {
 		goto error_alloc_mq_disk;
 	}
 
-	exp_obj->gd = gd;
+	tmp_exp_obj->gd = gd;
 
-	result = _cas_exp_obj_set_dev_t(exp_obj, gd);
+	result = _cas_exp_obj_set_dev_t(tmp_exp_obj, gd);
 	if (result)
 		goto error_exp_obj_set_dev_t;
 
 	BUG_ON(queue->queuedata);
-	queue->queuedata = exp_obj;
-	exp_obj->queue = queue;
+	queue->queuedata = tmp_exp_obj;
+	tmp_exp_obj->queue = queue;
 
-	_cas_init_queues(exp_obj);
+	_cas_init_queues(tmp_exp_obj);
 
 	gd->fops = &_cas_exp_obj_ops;
-	gd->private_data = exp_obj;
-	strscpy(gd->disk_name, exp_obj->dev_name, sizeof(gd->disk_name));
+	gd->private_data = tmp_exp_obj;
+	strscpy(gd->disk_name, tmp_exp_obj->dev_name, sizeof(gd->disk_name));
 
 	cas_blk_queue_make_request(queue, _cas_exp_obj_make_rq_fn);
 
-	if (exp_obj->ops->set_geometry) {
-		result = exp_obj->ops->set_geometry(exp_obj);
+	if (tmp_exp_obj->ops->set_geometry) {
+		result = tmp_exp_obj->ops->set_geometry(tmp_exp_obj);
 		if (result)
 			goto error_set_geometry;
 	}
@@ -420,37 +421,39 @@ struct cas_exp_obj *cas_exp_obj_create(struct cas_disk *dsk,
 	if (result)
 		goto error_sysfs;
 
-	result = bd_claim_by_disk(cas_disk_get_blkdev(dsk), exp_obj, gd);
+	result = bd_claim_by_disk(cas_disk_get_blkdev(dsk), tmp_exp_obj, gd);
 	if (result)
 		goto error_bd_claim;
 
-	return exp_obj;
+	*exp_obj = tmp_exp_obj;
+
+	return 0;
 
 
 error_bd_claim:
 	sysfs_remove_group(&disk_to_dev(gd)->kobj, &device_attr_group);
 error_sysfs:
-	del_gendisk(exp_obj->gd);
+	del_gendisk(tmp_exp_obj->gd);
 error_add_disk:
 error_set_geometry:
-	exp_obj->private = NULL;
-	_cas_exp_obj_clear_dev_t(exp_obj);
+	tmp_exp_obj->private = NULL;
+	_cas_exp_obj_clear_dev_t(tmp_exp_obj);
 error_exp_obj_set_dev_t:
 	cas_cleanup_disk(gd);
-	exp_obj->gd = NULL;
+	tmp_exp_obj->gd = NULL;
 error_alloc_mq_disk:
 error_set_queue_limits:
-	blk_mq_free_tag_set(&exp_obj->tag_set);
+	blk_mq_free_tag_set(&tmp_exp_obj->tag_set);
 error_init_tag_set:
 	module_put(owner);
-	exp_obj->owner = NULL;
+	tmp_exp_obj->owner = NULL;
 error_module_get:
-	kfree(exp_obj->dev_name);
+	kfree(tmp_exp_obj->dev_name);
 error_kstrdup:
 error_hide_parts:
-	cas_disk_put(exp_obj->dsk);
-	cas_exp_obj_free(exp_obj);
-	return ERR_PTR(result);
+	cas_disk_put(tmp_exp_obj->dsk);
+	cas_exp_obj_free(tmp_exp_obj);
+	return result;
 
 }
 EXPORT_SYMBOL(cas_exp_obj_create);

--- a/modules/cas_bd/exp_obj.h
+++ b/modules/cas_bd/exp_obj.h
@@ -35,14 +35,15 @@ struct cas_exp_obj_ops {
 
 /**
  * @brief Create exported object (top device)
+ * @param exp_obj Double pointer to exp_obj (out parameter)
  * @param dsk Pointer to a structure representing a backend block device
  * @param dev_name Name of exported object (top device)
  * @param owner Pointer to cas module
  * @param ops Pointer to structure with callback functions
  * @param priv Private data
- * @return Pointer to an exported object
+ * @return 0 if success, error code if failure
  */
-struct cas_exp_obj *cas_exp_obj_create(struct cas_disk *dsk,
+int cas_exp_obj_create(struct cas_exp_obj **exp_obj, struct cas_disk *dsk,
 		const char *dev_name, struct module *owner,
 		struct cas_exp_obj_ops *ops, void *priv);
 

--- a/modules/cas_bd/exp_obj_box.c
+++ b/modules/cas_bd/exp_obj_box.c
@@ -26,31 +26,32 @@ void cas_exp_obj_box_deposit(struct cas_exp_obj *exp_obj)
 }
 EXPORT_SYMBOL(cas_exp_obj_box_deposit);
 
-struct cas_exp_obj *cas_exp_obj_box_claim(struct cas_disk *dsk,
+int cas_exp_obj_box_claim(struct cas_exp_obj **exp_obj, struct cas_disk *dsk,
 		struct module *owner, struct cas_exp_obj_ops *ops, void *priv)
 {
-	struct cas_exp_obj *exp_obj;
+	struct cas_exp_obj *tmp_exp_obj;
 
 	if (!try_module_get(owner))
-		return ERR_PTR(-ENAVAIL);
+		return -ENAVAIL;
 
 	mutex_lock(&box_mutex);
-	list_for_each_entry(exp_obj, &box_list, list) {
-		if (exp_obj->dsk == dsk) {
-			list_del(&exp_obj->list);
-			module_put(exp_obj->owner);
-			exp_obj->owner = owner;
-			exp_obj->ops = ops;
-			exp_obj->private = priv;
+	list_for_each_entry(tmp_exp_obj, &box_list, list) {
+		if (tmp_exp_obj->dsk == dsk) {
+			list_del(&tmp_exp_obj->list);
+			module_put(tmp_exp_obj->owner);
+			tmp_exp_obj->owner = owner;
+			tmp_exp_obj->ops = ops;
+			tmp_exp_obj->private = priv;
 			mutex_unlock(&box_mutex);
-			return exp_obj;
+			*exp_obj = tmp_exp_obj;
+			return 0;
 		}
 	}
 	mutex_unlock(&box_mutex);
 
 	module_put(owner);
 
-	return ERR_PTR(-ENODEV);
+	return -ENODEV;
 }
 EXPORT_SYMBOL(cas_exp_obj_box_claim);
 

--- a/modules/cas_bd/exp_obj_box.h
+++ b/modules/cas_bd/exp_obj_box.h
@@ -22,13 +22,14 @@ void cas_exp_obj_box_deposit(struct cas_exp_obj *exp_obj);
 
 /**
  * @brief Claim exported object from the box by its underlying disk
+ * @param exp_obj Double pointer to exp_obj (out parameter)
  * @param dsk Pointer to cas_disk
  * @param owner Pointer to cas module
  * @param ops Pointer to structure with callback functions
  * @param priv Private data
- * @return Pointer to exp_obj on success, ERR_PTR on failure
+ * @return 0 if success, error code if failure
  */
-struct cas_exp_obj *cas_exp_obj_box_claim(struct cas_disk *dsk,
+int cas_exp_obj_box_claim(struct cas_exp_obj **exp_obj, struct cas_disk *dsk,
 		struct module *owner, struct cas_exp_obj_ops *ops, void *priv);
 
 #endif

--- a/modules/cas_cache/volume/vol_block_dev_top.c
+++ b/modules/cas_cache/volume/vol_block_dev_top.c
@@ -568,13 +568,15 @@ static int kcas_create_exported_object(struct cas_priv_top *priv_top,
 		goto end;
 	}
 
-	if (!claim)
-		exp_obj = cas_exp_obj_create(dsk, name, THIS_MODULE, ops, priv);
-	else
-		exp_obj = cas_exp_obj_box_claim(dsk, THIS_MODULE, ops, priv);
-	if (IS_ERR_OR_NULL(exp_obj)) {
+	if (!claim) {
+		result = cas_exp_obj_create(&exp_obj, dsk, name, THIS_MODULE,
+				ops, priv);
+	} else {
+		result = cas_exp_obj_box_claim(&exp_obj, dsk, THIS_MODULE,
+				ops, priv);
+	}
+	if (result) {
 		destroy_workqueue(priv_top->expobj_wq);
-		result = PTR_ERR(exp_obj);
 		goto end;
 	}
 


### PR DESCRIPTION
Return the error code by value instead of using ERR_PTR(). Some of the ops may return KCAS_* error codes which are in a range beyond of what ERR_PTR() can correctly handle, leading to an error code like that being interpreded as no error by IS_ERR().