### PR TITLE
cas_bd: Make cas_disk_open() exclusive

### DIFF
--- a/modules/cas_bd/disk.c
+++ b/modules/cas_bd/disk.c
@@ -208,6 +208,12 @@ struct cas_disk *cas_disk_open(const char *path)
 	mutex_lock(&disk_global.lock);
 	dsk = cas_disk_lookup(path);
 	if (dsk) {
+		if (dsk->claimed) {
+			mutex_unlock(&disk_global.lock);
+			CAS_DEBUG_ERROR("Disk already in use");
+			return ERR_PTR(-EBUSY);
+		}
+		dsk->claimed = true;
 		dsk->refcount++;
 		mutex_unlock(&disk_global.lock);
 		return dsk;
@@ -235,6 +241,7 @@ struct cas_disk *cas_disk_open(const char *path)
 	}
 
 	dsk->refcount = 1;
+	dsk->claimed = true;
 
 	mutex_lock(&disk_global.lock);
 	list_add_tail(&dsk->list, &disk_global.disks);
@@ -252,6 +259,19 @@ error_kmem:
 	return ERR_PTR(result);
 }
 EXPORT_SYMBOL(cas_disk_open);
+
+void cas_disk_release(struct cas_disk *dsk)
+{
+	BUG_ON(!dsk);
+
+	mutex_lock(&disk_global.lock);
+	BUG_ON(!dsk->claimed);
+	dsk->claimed = false;
+	mutex_unlock(&disk_global.lock);
+
+	cas_disk_put(dsk);
+}
+EXPORT_SYMBOL(cas_disk_release);
 
 void cas_disk_get(struct cas_disk *dsk)
 {

--- a/modules/cas_bd/disk.h
+++ b/modules/cas_bd/disk.h
@@ -11,11 +11,18 @@
 struct cas_disk;
 
 /**
- * @brief Open block device
+ * @brief Open block device exclusively
+ *
  * @param path Path to block device
- * @return Pointer to cas_disk related to opened block device
+ * @return Pointer to cas_disk related to opened block device, or ERR_PTR
  */
 struct cas_disk *cas_disk_open(const char *path);
+
+/**
+ * @brief Release exclusive claim on block device
+ * @param dsk Pointer to cas_disk structure
+ */
+void cas_disk_release(struct cas_disk *dsk);
 
 /**
  * @brief Increment reference count of cas_disk
@@ -24,9 +31,8 @@ struct cas_disk *cas_disk_open(const char *path);
 void cas_disk_get(struct cas_disk *dsk);
 
 /**
- * @brief Close block device and remove from cas
- * @param dsk Pointer to cas_disk structure related to block device
- *	which should be closed.
+ * @brief Decrement refcount of block device, close and deinit it at zero
+ * @param dsk Pointer to cas_disk structure
  */
 void cas_disk_put(struct cas_disk *dsk);
 

--- a/modules/cas_bd/disk_priv.h
+++ b/modules/cas_bd/disk_priv.h
@@ -17,6 +17,7 @@ struct cas_disk {
 	cas_bdev_handle_t bdev_handle;
 
 	int refcount;
+	bool claimed;
 	bool hidden;
 
 	int gd_flags;

--- a/modules/cas_cache/volume/vol_block_dev_bottom.c
+++ b/modules/cas_cache/volume/vol_block_dev_bottom.c
@@ -60,7 +60,7 @@ static void block_dev_close_object(ocf_volume_t vol)
 	if (priv_bottom->opened_by_bdev)
 		return;
 
-	cas_disk_put(priv_bottom->dsk);
+	cas_disk_release(priv_bottom->dsk);
 }
 
 static unsigned int block_dev_get_max_io_size(ocf_volume_t vol)


### PR DESCRIPTION
Track active openers by introducing claimed flag, and make sure there is only one active opener at any time.

We do it this way to separate cas_disk open exclusivity from the actual block device open/close, as the block device needs to survive in the opened state being deposited in the box and then claimed back by cas_disk_open().